### PR TITLE
Initial implementation of restconfig service

### DIFF
--- a/docker-base-java/Dockerfile
+++ b/docker-base-java/Dockerfile
@@ -1,3 +1,10 @@
 FROM adoptopenjdk/openjdk11:slim
 
-MAINTAINER GeoServer PSC <geoserver-users@lists.sourceforge.net>
+LABEL maintainer="GeoServer PSC <geoserver-users@lists.sourceforge.net>"
+
+# Add dockerize tool -------------------
+RUN apt-get update && apt-get install -y wget
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,3 +99,14 @@ services:
       JAVA_OPTS: -Xmx512m
     networks:
       - gs-cloud-network
+
+  # WPS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wps=5)
+  rest:
+    image: org.geoserver.cloud/gs-cloud-restconfig-v1:${TAG}
+    depends_on:
+      - config-service
+    environment:
+      EUREKA_SERVER_URL: ${EUREKA_SERVER_URL}
+      JAVA_OPTS: -Xmx256m
+    networks:
+      - gs-cloud-network

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -27,5 +27,6 @@
     <module>wms</module>
     <module>wcs</module>
     <module>wps</module>
+    <module>restconfig</module>
   </modules>
 </project>

--- a/services/restconfig/Dockerfile
+++ b/services/restconfig/Dockerfile
@@ -1,0 +1,7 @@
+FROM org.geoserver.cloud/gs-cloud-docker-base-java:latest
+
+ARG JAR_FILE=dummy
+
+ADD target/${JAR_FILE} /opt/restconfig-service.jar
+
+ENTRYPOINT exec java $JAVA_OPTS -jar /opt/restconfig-service.jar

--- a/services/restconfig/pom.xml
+++ b/services/restconfig/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.geoserver.cloud</groupId>
+    <artifactId>gs-microservices</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>gs-cloud-restconfig-v1</artifactId>
+  <name>restconfig-service</name>
+  <packaging>jar</packaging>
+  <properties>
+    <start-class>org.geoserver.cloud.restconfig.RestConfigApplication</start-class>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-config-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.retry</groupId>
+      <artifactId>spring-retry</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-aop</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-restconfig</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build-info</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.spotify</groupId>
+        <artifactId>dockerfile-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/services/restconfig/src/main/java/org/geoserver/cloud/restconfig/RestConfigApplication.java
+++ b/services/restconfig/src/main/java/org/geoserver/cloud/restconfig/RestConfigApplication.java
@@ -1,0 +1,51 @@
+/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.restconfig;
+
+import org.geoserver.cloud.core.GeoServerServletConfig;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+@SpringBootApplication(
+    exclude = { //
+        DataSourceAutoConfiguration.class, //
+        DataSourceTransactionManagerAutoConfiguration.class, //
+        HibernateJpaAutoConfiguration.class, //
+        SecurityAutoConfiguration.class, //
+        UserDetailsServiceAutoConfiguration.class, //
+        ManagementWebSecurityAutoConfiguration.class
+    }
+)
+@Import({ //
+    GeoServerServletConfig.class,
+    org.geoserver.rest.RestConfiguration.class //
+})
+public class RestConfigApplication {
+
+    public static void main(String[] args) {
+        try {
+            SpringApplication.run(RestConfigApplication.class, args);
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+
+    @ConditionalOnMissingBean(RequestMappingHandlerMapping.class)
+    public @Bean RequestMappingHandlerMapping requestMappingHandlerMapping() {
+        RequestMappingHandlerMapping mapping = new RequestMappingHandlerMapping();
+        return mapping;
+    }
+}

--- a/services/restconfig/src/main/resources/bootstrap.yml
+++ b/services/restconfig/src/main/resources/bootstrap.yml
@@ -1,0 +1,24 @@
+spring:
+   main:
+      banner-mode: 'off'
+   application:
+      name: restconfig-v1
+   cloud:
+      config:
+         fail-fast: true
+         retry:
+            max-attempts: 20
+         discovery:
+            enabled: true
+            service-id: config-service
+eureka:
+   instance:
+      hostname: ${spring.application.name}
+      preferIpAddress: true
+      instance-id: ${spring.application.name}@${spring.application.instance_id:${spring.cloud.client.ip-address}}
+   client:
+      enabled: true
+      serviceUrl:
+         defaultZone: ${eureka.server.url:http://localhost:8761/eureka}
+      healthcheck:
+         enabled: false

--- a/services/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationTests.java
+++ b/services/restconfig/src/test/java/org/geoserver/cloud/restconfig/RestConfigApplicationTests.java
@@ -1,0 +1,20 @@
+/* (c) 2020 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.cloud.restconfig;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@ActiveProfiles("test")
+public class RestConfigApplicationTests {
+
+    @Test
+    public void contextLoads() {}
+}

--- a/services/wcs/src/main/java/org/geoserver/cloud/wcs/WcsApplication.java
+++ b/services/wcs/src/main/java/org/geoserver/cloud/wcs/WcsApplication.java
@@ -13,7 +13,6 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerA
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
-import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.Import;
 
 @SpringBootApplication(
@@ -27,7 +26,6 @@ import org.springframework.context.annotation.Import;
     }
 )
 @Import(GeoServerServletConfig.class)
-@EnableDiscoveryClient
 public class WcsApplication {
 
     public static void main(String[] args) {

--- a/services/wfs/src/main/java/org/geoserver/cloud/wfs/WfsApplication.java
+++ b/services/wfs/src/main/java/org/geoserver/cloud/wfs/WfsApplication.java
@@ -13,7 +13,6 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerA
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
-import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.Import;
 
 @SpringBootApplication(
@@ -27,7 +26,6 @@ import org.springframework.context.annotation.Import;
     }
 )
 @Import(GeoServerServletConfig.class)
-@EnableDiscoveryClient
 public class WfsApplication {
 
     public static void main(String[] args) {

--- a/services/wms/src/main/java/org/geoserver/cloud/wms/WmsApplication.java
+++ b/services/wms/src/main/java/org/geoserver/cloud/wms/WmsApplication.java
@@ -13,7 +13,6 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerA
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
-import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.Import;
 
 @SpringBootApplication(
@@ -27,7 +26,6 @@ import org.springframework.context.annotation.Import;
     }
 )
 @Import(GeoServerServletConfig.class)
-@EnableDiscoveryClient
 public class WmsApplication {
 
     public static void main(String[] args) {

--- a/services/wps/src/main/java/org/geoserver/cloud/wcs/WpsApplication.java
+++ b/services/wps/src/main/java/org/geoserver/cloud/wcs/WpsApplication.java
@@ -13,7 +13,6 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerA
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
-import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.Import;
 
 @SpringBootApplication(
@@ -27,7 +26,6 @@ import org.springframework.context.annotation.Import;
     }
 )
 @Import(GeoServerServletConfig.class)
-@EnableDiscoveryClient
 public class WpsApplication {
 
     public static void main(String[] args) {

--- a/support-services/config/src/main/java/org/geoserver/cloud/config/ConfigApplication.java
+++ b/support-services/config/src/main/java/org/geoserver/cloud/config/ConfigApplication.java
@@ -6,12 +6,10 @@ package org.geoserver.cloud.config;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.config.server.EnableConfigServer;
 
 @SpringBootApplication
 @EnableConfigServer
-@EnableDiscoveryClient
 public class ConfigApplication {
 
     public static void main(String[] args) {

--- a/support-services/config/src/main/resources/config/gateway-service.yml
+++ b/support-services/config/src/main/resources/config/gateway-service.yml
@@ -59,10 +59,9 @@ spring:
       - id: restconfig
         uri: lb://restconfig-v1 #load balanced to the restconfig-v1 instances
         predicates:
-        - Path=/rest
         - Path=/rest/**
         filters:
-        - RewritePath=/(?<rest>.*), /$\{rest}
+         - RewritePath=/rest/(?<segment>.*), /rest/$\{segment}
 
 logging:
   level:

--- a/support-services/config/src/main/resources/config/restconfig-v1.yml
+++ b/support-services/config/src/main/resources/config/restconfig-v1.yml
@@ -6,3 +6,4 @@ server:
 logging:
    level:
       org.springframework: ERROR
+      oshi.hardware.platform.linux: OFF

--- a/support-services/config/src/main/resources/config/wcs-service.yml
+++ b/support-services/config/src/main/resources/config/wcs-service.yml
@@ -6,3 +6,4 @@ server:
 logging:
    level:
       org.springframework: ERROR
+      oshi.hardware.platform.linux: OFF

--- a/support-services/config/src/main/resources/config/wfs-service.yml
+++ b/support-services/config/src/main/resources/config/wfs-service.yml
@@ -6,3 +6,4 @@ server:
 logging:
    level:
       org.springframework: ERROR
+      oshi.hardware.platform.linux: OFF

--- a/support-services/config/src/main/resources/config/wms-service.yml
+++ b/support-services/config/src/main/resources/config/wms-service.yml
@@ -6,3 +6,4 @@ server:
 logging:
    level:
       org.springframework: ERROR
+      oshi.hardware.platform.linux: OFF

--- a/support-services/config/src/main/resources/config/wps-service.yml
+++ b/support-services/config/src/main/resources/config/wps-service.yml
@@ -6,3 +6,4 @@ server:
 logging:
    level:
       org.springframework: ERROR
+      oshi.hardware.platform.linux: OFF


### PR DESCRIPTION
Initial implementation of restconfig service
    
REVISIT: Requests to `<gateway-service>/rest/**` are correctly dispatched to `<restconfig-v1-service>/rest/**`, yet geoserver's rest FTL templates for HTML output create links like to `/rest/null/**`
    
And of course these URLs, as any other one generated by geoserver (e.g. in capabilities documents), still need to be proxified, since they point to the container's internal IP and not the gateway's.
