### PR TITLE
URL-proxifying and OWS gateway routing

### DIFF
--- a/services/common/src/main/java/org/geoserver/cloud/core/UrlProxifyingConfiguration.java
+++ b/services/common/src/main/java/org/geoserver/cloud/core/UrlProxifyingConfiguration.java
@@ -1,0 +1,54 @@
+package org.geoserver.cloud.core;
+
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import org.geoserver.config.GeoServerInfo;
+import org.geoserver.ows.Dispatcher;
+import org.geoserver.ows.ProxifyingURLMangler;
+import org.geoserver.ows.Request;
+import org.geoserver.ows.URLMangler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class UrlProxifyingConfiguration {
+
+    /**
+     * {@link URLMangler} to adapt returned URL's to the gateway-service provided {@code
+     * X-Forwarded-Proto}, {@code X-Forwarded-Host}, and {@code X-Forwarded-Path} request headers.
+     *
+     * <p>Unlike the regular {@link ProxifyingURLMangler}, this {@link URLMangler} does not depend
+     * on {@link GeoServerInfo#isUseHeadersProxyURL() geoserver's configuration}, but always adapts
+     * URL's if the request headers are given. </pre>
+     */
+    public @Primary @Bean URLMangler cloudProxifyingURLMangler() {
+        return new CloudProxifyingURLMangler();
+    }
+
+    private static class CloudProxifyingURLMangler implements URLMangler {
+
+        @Override
+        public void mangleURL(
+                StringBuilder baseURL, StringBuilder path, Map<String, String> kvp, URLType type) {
+            // If the request is not an OWS request, does not proxy the URL
+            Request request = Dispatcher.REQUEST.get();
+            if (request == null) {
+                return;
+            }
+            HttpServletRequest httpRequest = request.getHttpRequest();
+            String fproto = httpRequest.getHeader("X-Forwarded-Proto");
+            String fhost = httpRequest.getHeader("X-Forwarded-Host");
+            String fpath = httpRequest.getHeader("X-Forwarded-Path");
+            if (fproto == null || fhost == null) {
+                return;
+            }
+            if (fpath == null) {
+                fpath = "";
+            }
+            String proxyfiedURL = String.format("%s://%s/%s", fproto, fhost, fpath);
+            baseURL.setLength(0);
+            baseURL.append(proxyfiedURL);
+        }
+    }
+}

--- a/services/restconfig/src/main/java/org/geoserver/cloud/restconfig/RestConfigApplication.java
+++ b/services/restconfig/src/main/java/org/geoserver/cloud/restconfig/RestConfigApplication.java
@@ -8,15 +8,12 @@ import org.geoserver.cloud.core.GeoServerServletConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 @SpringBootApplication(
     exclude = { //
@@ -43,9 +40,9 @@ public class RestConfigApplication {
         }
     }
 
-    @ConditionalOnMissingBean(RequestMappingHandlerMapping.class)
-    public @Bean RequestMappingHandlerMapping requestMappingHandlerMapping() {
-        RequestMappingHandlerMapping mapping = new RequestMappingHandlerMapping();
-        return mapping;
-    }
+    // @ConditionalOnMissingBean(RequestMappingHandlerMapping.class)
+    // public @Bean RequestMappingHandlerMapping requestMappingHandlerMapping() {
+    // RequestMappingHandlerMapping mapping = new RequestMappingHandlerMapping();
+    // return mapping;
+    // }
 }

--- a/services/wcs/src/main/java/org/geoserver/cloud/wcs/WCSController.java
+++ b/services/wcs/src/main/java/org/geoserver/cloud/wcs/WCSController.java
@@ -4,6 +4,9 @@
  */
 package org.geoserver.cloud.wcs;
 
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import static org.springframework.web.bind.annotation.RequestMethod.POST;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.geoserver.ows.Dispatcher;
@@ -25,7 +28,10 @@ public @Controller class WCSController {
         classPathPublisher.handleRequest(request, response);
     }
 
-    @RequestMapping(method = RequestMethod.GET, path = "/wcs")
+    @RequestMapping(
+        method = {GET, POST},
+        path = {"/wcs", "/{workspace}/wcs", "/ows", "/{workspace}/ows"}
+    )
     public void handle(HttpServletRequest request, HttpServletResponse response) throws Exception {
         geoserverDispatcher.handleRequest(request, response);
     }

--- a/services/wcs/src/main/java/org/geoserver/cloud/wcs/WCSController.java
+++ b/services/wcs/src/main/java/org/geoserver/cloud/wcs/WCSController.java
@@ -16,6 +16,15 @@ public @Controller class WCSController {
 
     private @Autowired Dispatcher geoserverDispatcher;
 
+    private @Autowired org.geoserver.ows.ClasspathPublisher classPathPublisher;
+
+    /** Serve only WCS schemas from classpath (e.g. {@code /schemas/wcs/1.1.1/wcsAll.xsd}) */
+    @RequestMapping(method = RequestMethod.GET, path = "/schemas/wcs/**")
+    public void getSchema(HttpServletRequest request, HttpServletResponse response)
+            throws Exception {
+        classPathPublisher.handleRequest(request, response);
+    }
+
     @RequestMapping(method = RequestMethod.GET, path = "/wcs")
     public void handle(HttpServletRequest request, HttpServletResponse response) throws Exception {
         geoserverDispatcher.handleRequest(request, response);

--- a/services/wcs/src/main/java/org/geoserver/cloud/wcs/WcsApplication.java
+++ b/services/wcs/src/main/java/org/geoserver/cloud/wcs/WcsApplication.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.wcs;
 
 import org.geoserver.cloud.core.GeoServerServletConfig;
+import org.geoserver.cloud.core.UrlProxifyingConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -25,7 +26,7 @@ import org.springframework.context.annotation.Import;
         ManagementWebSecurityAutoConfiguration.class
     }
 )
-@Import(GeoServerServletConfig.class)
+@Import({GeoServerServletConfig.class, UrlProxifyingConfiguration.class})
 public class WcsApplication {
 
     public static void main(String[] args) {

--- a/services/wfs/src/main/java/org/geoserver/cloud/wfs/WFSController.java
+++ b/services/wfs/src/main/java/org/geoserver/cloud/wfs/WFSController.java
@@ -4,6 +4,9 @@
  */
 package org.geoserver.cloud.wfs;
 
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import static org.springframework.web.bind.annotation.RequestMethod.POST;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.geoserver.ows.Dispatcher;
@@ -13,7 +16,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 @RequestMapping("/")
-public @Controller class WFSController {
+@Controller
+public class WFSController {
 
     private @Autowired Dispatcher geoserverDispatcher;
 
@@ -26,7 +30,10 @@ public @Controller class WFSController {
         classPathPublisher.handleRequest(request, response);
     }
 
-    @RequestMapping(method = RequestMethod.GET, path = "/wfs")
+    @RequestMapping(
+        method = {GET, POST},
+        path = {"/wfs", "/{workspace}/wfs", "/ows", "/{workspace}/ows"}
+    )
     public void serviceRequest(HttpServletRequest request, HttpServletResponse response)
             throws Exception {
         geoserverDispatcher.handleRequest(request, response);

--- a/services/wfs/src/main/java/org/geoserver/cloud/wfs/WFSController.java
+++ b/services/wfs/src/main/java/org/geoserver/cloud/wfs/WFSController.java
@@ -17,8 +17,18 @@ public @Controller class WFSController {
 
     private @Autowired Dispatcher geoserverDispatcher;
 
+    private @Autowired org.geoserver.ows.ClasspathPublisher classPathPublisher;
+
+    /** Serve only WFS schemas from classpath (e.g. {@code /schemas/wfs/2.0/wfs.xsd}) */
+    @RequestMapping(method = RequestMethod.GET, path = "/schemas/wfs/**")
+    public void getSchema(HttpServletRequest request, HttpServletResponse response)
+            throws Exception {
+        classPathPublisher.handleRequest(request, response);
+    }
+
     @RequestMapping(method = RequestMethod.GET, path = "/wfs")
-    public void handle(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public void serviceRequest(HttpServletRequest request, HttpServletResponse response)
+            throws Exception {
         geoserverDispatcher.handleRequest(request, response);
     }
 }

--- a/services/wfs/src/main/java/org/geoserver/cloud/wfs/WfsApplication.java
+++ b/services/wfs/src/main/java/org/geoserver/cloud/wfs/WfsApplication.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.wfs;
 
 import org.geoserver.cloud.core.GeoServerServletConfig;
+import org.geoserver.cloud.core.UrlProxifyingConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -25,7 +26,7 @@ import org.springframework.context.annotation.Import;
         ManagementWebSecurityAutoConfiguration.class
     }
 )
-@Import(GeoServerServletConfig.class)
+@Import({GeoServerServletConfig.class, UrlProxifyingConfiguration.class})
 public class WfsApplication {
 
     public static void main(String[] args) {

--- a/services/wfs/src/main/java/org/geoserver/cloud/wfs/WfsApplication.java
+++ b/services/wfs/src/main/java/org/geoserver/cloud/wfs/WfsApplication.java
@@ -14,7 +14,9 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerA
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 @SpringBootApplication(
     exclude = { //
@@ -36,5 +38,11 @@ public class WfsApplication {
             e.printStackTrace();
             throw e;
         }
+    }
+
+    // @ConditionalOnMissingBean(RequestMappingHandlerMapping.class)
+    public @Bean RequestMappingHandlerMapping requestMappingHandlerMapping() {
+        RequestMappingHandlerMapping mapping = new RequestMappingHandlerMapping();
+        return mapping;
     }
 }

--- a/services/wfs/src/main/resources/bootstrap.yml
+++ b/services/wfs/src/main/resources/bootstrap.yml
@@ -1,6 +1,7 @@
 spring:
    main:
       banner-mode: "off"
+      allow-bean-definition-overriding: true
    application:
       name: wfs-service
    cloud:
@@ -16,7 +17,7 @@ eureka:
       hostname: ${spring.application.name}
       preferIpAddress: true
       instance-id: ${spring.application.name}@${spring.application.instance_id:${spring.cloud.client.ip-address}}
-      leaseRenewalIntervalInSeconds: 5
+      #leaseRenewalIntervalInSeconds: 5
    client:
       enabled: true
       fetchRegistry: true

--- a/services/wms/src/main/java/org/geoserver/cloud/wms/WMSController.java
+++ b/services/wms/src/main/java/org/geoserver/cloud/wms/WMSController.java
@@ -16,6 +16,29 @@ public @Controller class WMSController {
 
     private @Autowired Dispatcher geoserverDispatcher;
 
+    private @Autowired org.geoserver.ows.ClasspathPublisher classPathPublisher;
+
+    /**
+     * Serve only WMS schemas and related resources from classpath.
+     *
+     * <p>E.g.:
+     *
+     * <ul>
+     *   <li>{@code /schemas/wms/1.3.0/capabilities_1_3_0.xsd}
+     *   <li>{@code /schemas/wms/1.1.1/WMS_MS_Capabilities.dtd}
+     *   <li>{@code /openlayers/**}
+     *   <li>{@code /openlayers3/**}
+     * </ul>
+     */
+    @RequestMapping(
+        method = RequestMethod.GET,
+        path = {"/schemas/wms/**", "/openlayers/**", "/openlayers3/**"}
+    )
+    public void getStaticResource(HttpServletRequest request, HttpServletResponse response)
+            throws Exception {
+        classPathPublisher.handleRequest(request, response);
+    }
+
     @RequestMapping(method = RequestMethod.GET, path = "/wms")
     public void handle(HttpServletRequest request, HttpServletResponse response) throws Exception {
         geoserverDispatcher.handleRequest(request, response);

--- a/services/wms/src/main/java/org/geoserver/cloud/wms/WMSController.java
+++ b/services/wms/src/main/java/org/geoserver/cloud/wms/WMSController.java
@@ -4,6 +4,9 @@
  */
 package org.geoserver.cloud.wms;
 
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import static org.springframework.web.bind.annotation.RequestMethod.POST;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.geoserver.ows.Dispatcher;
@@ -39,7 +42,10 @@ public @Controller class WMSController {
         classPathPublisher.handleRequest(request, response);
     }
 
-    @RequestMapping(method = RequestMethod.GET, path = "/wms")
+    @RequestMapping(
+        method = {GET, POST},
+        path = {"/wms", "/{workspace}/wms", "/ows", "/{workspace}/ows"}
+    )
     public void handle(HttpServletRequest request, HttpServletResponse response) throws Exception {
         geoserverDispatcher.handleRequest(request, response);
     }

--- a/services/wms/src/main/java/org/geoserver/cloud/wms/WmsApplication.java
+++ b/services/wms/src/main/java/org/geoserver/cloud/wms/WmsApplication.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.wms;
 
 import org.geoserver.cloud.core.GeoServerServletConfig;
+import org.geoserver.cloud.core.UrlProxifyingConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -25,7 +26,7 @@ import org.springframework.context.annotation.Import;
         ManagementWebSecurityAutoConfiguration.class
     }
 )
-@Import(GeoServerServletConfig.class)
+@Import({GeoServerServletConfig.class, UrlProxifyingConfiguration.class})
 public class WmsApplication {
 
     public static void main(String[] args) {

--- a/services/wps/src/main/java/org/geoserver/cloud/wcs/WPSController.java
+++ b/services/wps/src/main/java/org/geoserver/cloud/wcs/WPSController.java
@@ -4,6 +4,8 @@
  */
 package org.geoserver.cloud.wcs;
 
+import static org.springframework.web.bind.annotation.RequestMethod.*;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.geoserver.ows.Dispatcher;
@@ -25,7 +27,10 @@ public @Controller class WPSController {
         classPathPublisher.handleRequest(request, response);
     }
 
-    @RequestMapping(method = RequestMethod.GET, path = "/wps")
+    @RequestMapping(
+        method = {GET, POST},
+        path = {"/wps", "/{workspace}/wps", "/ows", "/{workspace}/ows"}
+    )
     public void handle(HttpServletRequest request, HttpServletResponse response) throws Exception {
         geoserverDispatcher.handleRequest(request, response);
     }

--- a/services/wps/src/main/java/org/geoserver/cloud/wcs/WPSController.java
+++ b/services/wps/src/main/java/org/geoserver/cloud/wcs/WPSController.java
@@ -16,6 +16,15 @@ public @Controller class WPSController {
 
     private @Autowired Dispatcher geoserverDispatcher;
 
+    private @Autowired org.geoserver.ows.ClasspathPublisher classPathPublisher;
+
+    /** Serve only WPS schemas from classpath (e.g. {@code /schemas/wps/1.0.0/wpsAll.xsd}) */
+    @RequestMapping(method = RequestMethod.GET, path = "/schemas/wps/**")
+    public void getSchema(HttpServletRequest request, HttpServletResponse response)
+            throws Exception {
+        classPathPublisher.handleRequest(request, response);
+    }
+
     @RequestMapping(method = RequestMethod.GET, path = "/wps")
     public void handle(HttpServletRequest request, HttpServletResponse response) throws Exception {
         geoserverDispatcher.handleRequest(request, response);

--- a/services/wps/src/main/java/org/geoserver/cloud/wcs/WpsApplication.java
+++ b/services/wps/src/main/java/org/geoserver/cloud/wcs/WpsApplication.java
@@ -5,6 +5,7 @@
 package org.geoserver.cloud.wcs;
 
 import org.geoserver.cloud.core.GeoServerServletConfig;
+import org.geoserver.cloud.core.UrlProxifyingConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -25,7 +26,7 @@ import org.springframework.context.annotation.Import;
         ManagementWebSecurityAutoConfiguration.class
     }
 )
-@Import(GeoServerServletConfig.class)
+@Import({GeoServerServletConfig.class, UrlProxifyingConfiguration.class})
 public class WpsApplication {
 
     public static void main(String[] args) {

--- a/support-services/config/src/main/resources/config/gateway-service.yml
+++ b/support-services/config/src/main/resources/config/gateway-service.yml
@@ -26,31 +26,47 @@ spring:
       - id: wfs # proxies requests to gateway-service:/wfs to wfs-service:/wfs
         uri: lb://wfs-service #load balanced to the wfs-service instances
         predicates:
-        - Path=/wfs,/schemas/wfs/**
-        #filters:
-        #- RewritePath=/(?<wfs>.*), /$\{wfs}
+        - Path=/wfs,/{segment}/wfs,/schemas/wfs/**
+        # proxy [/{workspace}]/ows?SERVICE=wfs to wfs-service:[/{workspace}]/ows?SERVICE=wfs. Param value is case insensitive, name is not.
+      - id: wfs_ows
+        uri: lb://wfs-service
+        predicates:
+        - Path=/ows,/{segment}/ows
+        - Query=SERVICE, (?i:WFS)
+
       # WMS routes
       - id: wms # proxies requests to gateway-service:/wms to wms-service:/wms
         uri: lb://wms-service #load balanced to the wms-service instances
         predicates:
-        - Path=/wms,/schemas/wms/**,/openlayers/**,/openlayers3/**
-#        filters:
-#        - RewritePath=/(?<wms>.*), /$\{wms}
-#        - AddResponseHeader=X-Some-Header, aboullaite.me
+        - Path=/wms,/{segment}/wms,/schemas/wms/**,/openlayers/**,/openlayers3/**
+      - id: wms_ows # proxy [/{workspace}]/ows?SERVICE=wms to wms-service:[/{workspace}]/ows?SERVICE=wms. Param value is case insensitive, name is not.
+        uri: lb://wms-service
+        predicates:
+        - Path=/ows,/{segment}/ows
+        - Query=SERVICE, (?i:WMS)
+
       # WCS routes
       - id: wcs # proxies requests to gateway-service:/wcs to wcs-service:/wcs
         uri: lb://wcs-service #load balanced to the wps-service instances
         predicates:
-        - Path=/wcs,/schemas/wcs/**
-#        filters:
-#        - RewritePath=/(?<wcs>.*), /$\{wcs}
+        - Path=/wcs,/{segment}/wcs,/schemas/wcs/**
+      - id: wcs_ows # proxy [/{workspace}]/ows?SERVICE=wcs to wcs-service:[/{workspace}]/ows?SERVICE=wcs. Param value is case insensitive, name is not.
+        uri: lb://wcs-service
+        predicates:
+        - Path=/ows,/{segment}/ows
+        - Query=SERVICE, (?i:WCS)
+
       # WPS routes
       - id: wps # proxies requests to gateway-service:/wps to wfs-service:/wps
         uri: lb://wps-service #load balanced to the wps-service instances
         predicates:
-        - Path=/wps,/schemas/wps/**
-#        filters:
-#        - RewritePath=/(?<wps>.*), /$\{wps}
+        - Path=/wps,/{segment}/wps,/schemas/wps/**
+      - id: wps_ows # proxy [/{workspace}]/ows?SERVICE=wps to wps-service:[/{workspace}]/ows?SERVICE=wps. Param value is case insensitive, name is not.
+        uri: lb://wps-service
+        predicates:
+        - Path=/ows,/{segment}/ows
+        - Query=SERVICE, (?i:WPS)
+
       # REST configuration routes
       - id: restconfig
         uri: lb://restconfig-v1 #load balanced to the restconfig-v1 instances

--- a/support-services/config/src/main/resources/config/gateway-service.yml
+++ b/support-services/config/src/main/resources/config/gateway-service.yml
@@ -26,42 +26,38 @@ spring:
       - id: wfs # proxies requests to gateway-service:/wfs to wfs-service:/wfs
         uri: lb://wfs-service #load balanced to the wfs-service instances
         predicates:
-        - Path=/wfs
-        - Path=/wfs/**
-        filters:
-        - RewritePath=/(?<wfs>.*), /$\{wfs}
+        - Path=/wfs,/schemas/wfs/**
+        #filters:
+        #- RewritePath=/(?<wfs>.*), /$\{wfs}
       # WMS routes
       - id: wms # proxies requests to gateway-service:/wms to wms-service:/wms
         uri: lb://wms-service #load balanced to the wms-service instances
         predicates:
-        - Path=/wms
-        - Path=/wms/**
-        filters:
-        - RewritePath=/(?<wms>.*), /$\{wms}
+        - Path=/wms,/schemas/wms/**,/openlayers/**,/openlayers3/**
+#        filters:
+#        - RewritePath=/(?<wms>.*), /$\{wms}
 #        - AddResponseHeader=X-Some-Header, aboullaite.me
       # WCS routes
       - id: wcs # proxies requests to gateway-service:/wcs to wcs-service:/wcs
         uri: lb://wcs-service #load balanced to the wps-service instances
         predicates:
-        - Path=/wcs
-        - Path=/wcs/**
-        filters:
-        - RewritePath=/(?<wcs>.*), /$\{wcs}
+        - Path=/wcs,/schemas/wcs/**
+#        filters:
+#        - RewritePath=/(?<wcs>.*), /$\{wcs}
       # WPS routes
       - id: wps # proxies requests to gateway-service:/wps to wfs-service:/wps
         uri: lb://wps-service #load balanced to the wps-service instances
         predicates:
-        - Path=/wps
-        - Path=/wps/**
-        filters:
-        - RewritePath=/(?<wps>.*), /$\{wps}
+        - Path=/wps,/schemas/wps/**
+#        filters:
+#        - RewritePath=/(?<wps>.*), /$\{wps}
       # REST configuration routes
       - id: restconfig
         uri: lb://restconfig-v1 #load balanced to the restconfig-v1 instances
         predicates:
         - Path=/rest/**
-        filters:
-         - RewritePath=/rest/(?<segment>.*), /rest/$\{segment}
+#        filters:
+#         - RewritePath=/rest/(?<segment>.*), /rest/$\{segment}
 
 logging:
   level:


### PR DESCRIPTION
- Return proxyfied URL's in the response body. E.g.: `<gateway-base-url>/wfs?` instead of `<wfs-internal-service-url>/wfs?`
- `GetCapabilities` requests return schema locations served by geoserver, and are accessible through the gateway too. E.g. `<gateway-base-url>/schemas/wfs/2.0/wfs.xsd` instead of `<wfs-internal-service-url>/schemas/wfs/2.0/wfs.xsd`
 Schema requests for a given OWS must be redirected to that OWS microservice.
- Requests to the generic OWS endpoint are redirected to the appropriate microservice based on the `SERVICE` request parameter (e.g. `/ows?SERVICE=WMS&...` to the WMS microservice, `/ows?SERVICE=WFS&...` to the WFS microservice, and so on.
- Local workspace routes are handled. E.g. `/topp/wms?`