### PR TITLE
Include JDBCStoreAutoConfiguration in GeoServerCatalogConfig

### DIFF
--- a/services/catalog/pom.xml
+++ b/services/catalog/pom.xml
@@ -12,8 +12,8 @@
   <packaging>jar</packaging>
   <dependencies>
     <dependency>
-      <groupId>org.geoserver</groupId>
-      <artifactId>gs-main</artifactId>
+      <groupId>org.geoserver.cloud</groupId>
+      <artifactId>gs-cloud-common</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/services/catalog/src/main/java/org/geoserver/cloud/autoconfigure/jdbcconfig/CloudJdbcConfigProperties.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/autoconfigure/jdbcconfig/CloudJdbcConfigProperties.java
@@ -1,0 +1,91 @@
+package org.geoserver.cloud.autoconfigure.jdbcconfig;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.net.URL;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import org.geoserver.jdbcconfig.internal.ConfigDatabase;
+import org.geoserver.jdbcconfig.internal.JDBCConfigProperties;
+import org.geoserver.jdbcconfig.internal.JDBCConfigPropertiesFactoryBean;
+import org.geoserver.jdbcloader.DataSourceFactoryBean;
+import org.geoserver.platform.resource.Resource;
+
+/** Extends {@link JDBCConfigProperties} to not need a {@link JDBCConfigPropertiesFactoryBean} */
+class CloudJdbcConfigProperties extends JDBCConfigProperties {
+    private static final long serialVersionUID = 1L;
+    private DataSource dataSource;
+
+    public CloudJdbcConfigProperties(DataSource dataSource) {
+        super((JDBCConfigPropertiesFactoryBean) null);
+        this.dataSource = dataSource;
+    }
+
+    /** Override to not save at all */
+    public @Override void save() throws IOException {
+        // factory.saveConfig(this);
+    }
+
+    /** Override to return {@code true} only if the db schema is not already created */
+    public @Override boolean isInitDb() {
+        // return Boolean.parseBoolean(getProperty("initdb", "false"));
+        boolean initDb = super.isInitDb();
+        if (initDb) {
+            try (Connection c = dataSource.getConnection();
+                    Statement st = c.createStatement()) {
+                try {
+                    st.executeQuery("select count(*) from object_property");
+                    initDb = false;
+                } catch (SQLException e) {
+                    // table not found, proceed with initialization
+                }
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return initDb;
+    }
+
+    /**
+     * Override to get the init script directly from the ones in the classpath (inside
+     * gs-jdbcconfig.jar)
+     */
+    public @Override Resource getInitScript() {
+        final String driverClassName = getProperty("datasource.driverClassname");
+        String scriptName;
+        switch (driverClassName) {
+            case "org.h2.Driver":
+                scriptName = "initdb.h2.sql";
+                break;
+            case "org.postgresql.Driver":
+                scriptName = "initdb.postgres.sql";
+                break;
+            default:
+                scriptName = null;
+        }
+        if (scriptName == null) {
+            return null;
+        }
+        URL initScript = ConfigDatabase.class.getResource(scriptName);
+        Preconditions.checkState(
+                initScript != null,
+                "Init script does not exist: %s/%s",
+                ConfigDatabase.class.getPackage().getName(),
+                scriptName);
+
+        Resource resource = org.geoserver.platform.resource.URIs.asResource(initScript);
+        return resource;
+    }
+
+    /**
+     * Override to throw an {@link UnsupportedOperationException}, we're not using {@link
+     * DataSourceFactoryBean}, the datasource is provided by spring instead
+     */
+    public @Override Optional<String> getJdbcUrl() {
+        throw new UnsupportedOperationException(
+                "shouldn't be called, this module doesn't use org.geoserver.jdbcloader.DataSourceFactoryBean");
+    }
+}

--- a/services/catalog/src/main/java/org/geoserver/cloud/autoconfigure/jdbcconfig/CloudJdbcStoreProperties.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/autoconfigure/jdbcconfig/CloudJdbcStoreProperties.java
@@ -1,0 +1,93 @@
+package org.geoserver.cloud.autoconfigure.jdbcconfig;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.net.URL;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import org.geoserver.jdbcloader.DataSourceFactoryBean;
+import org.geoserver.jdbcstore.internal.JDBCResourceStoreProperties;
+import org.geoserver.jdbcstore.internal.JDBCResourceStorePropertiesFactoryBean;
+import org.geoserver.platform.resource.Resource;
+
+/**
+ * Extends {@link JDBCResourceStoreProperties} to not need a {@link
+ * JDBCResourceStorePropertiesFactoryBean}
+ */
+class CloudJdbcStoreProperties extends JDBCResourceStoreProperties {
+    private static final long serialVersionUID = 1L;
+    private DataSource dataSource;
+
+    public CloudJdbcStoreProperties(DataSource dataSource) {
+        super((JDBCResourceStorePropertiesFactoryBean) null);
+        this.dataSource = dataSource;
+    }
+
+    /** Override to not save at all */
+    public @Override void save() throws IOException {
+        // factory.saveConfig(this);
+    }
+
+    /** Override to return {@code true} only if the db schema is not already created */
+    public @Override boolean isInitDb() {
+        // return Boolean.parseBoolean(getProperty("initdb", "false"));
+        boolean initDb = super.isInitDb();
+        if (initDb) {
+            try (Connection c = dataSource.getConnection();
+                    Statement st = c.createStatement()) {
+                try {
+                    st.executeQuery("select count(*) from resources");
+                    initDb = false;
+                } catch (SQLException e) {
+                    // table not found, proceed with initialization
+                }
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return initDb;
+    }
+
+    /**
+     * Override to get the init script directly from the ones in the classpath (inside
+     * gs-jdbcconfig.jar)
+     */
+    public @Override Resource getInitScript() {
+        final String driverClassName = getProperty("datasource.driverClassname");
+        String scriptName;
+        switch (driverClassName) {
+            case "org.h2.Driver":
+                scriptName = "init.h2.sql";
+                break;
+            case "org.postgresql.Driver":
+                scriptName = "init.postgres.sql";
+                break;
+            default:
+                scriptName = null;
+        }
+        if (scriptName == null) {
+            return null;
+        }
+        URL initScript = JDBCResourceStoreProperties.class.getResource(scriptName);
+        Preconditions.checkState(
+                initScript != null,
+                "Init script does not exist: %s/%s",
+                JDBCResourceStoreProperties.class.getPackage().getName(),
+                scriptName);
+
+        Resource resource = org.geoserver.platform.resource.URIs.asResource(initScript);
+        return resource;
+    }
+
+    /**
+     * Override to throw an {@link UnsupportedOperationException}, we're not using {@link
+     * DataSourceFactoryBean}, the datasource is provided by spring instead
+     */
+    public @Override Optional<String> getJdbcUrl() {
+        throw new UnsupportedOperationException(
+                "shouldn't be called, this module doesn't use org.geoserver.jdbcloader.DataSourceFactoryBean");
+    }
+}

--- a/services/catalog/src/main/java/org/geoserver/cloud/autoconfigure/jdbcconfig/JDBCConfigAutoConfiguration.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/autoconfigure/jdbcconfig/JDBCConfigAutoConfiguration.java
@@ -1,12 +1,5 @@
 package org.geoserver.cloud.autoconfigure.jdbcconfig;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
-import java.io.IOException;
-import java.net.URL;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
 import javax.sql.DataSource;
 import org.geoserver.config.util.XStreamPersisterFactory;
 import org.geoserver.jdbcconfig.JDBCGeoServerLoader;
@@ -15,172 +8,70 @@ import org.geoserver.jdbcconfig.config.JDBCGeoServerFacade;
 import org.geoserver.jdbcconfig.internal.ConfigDatabase;
 import org.geoserver.jdbcconfig.internal.JDBCCacheProvider;
 import org.geoserver.jdbcconfig.internal.JDBCConfigProperties;
-import org.geoserver.jdbcconfig.internal.JDBCConfigPropertiesFactoryBean;
 import org.geoserver.jdbcconfig.internal.JDBCConfigXStreamPersisterInitializer;
 import org.geoserver.jdbcconfig.internal.XStreamInfoSerialBinding;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.platform.resource.DataDirectoryResourceStore;
-import org.geoserver.platform.resource.Resource;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
-import org.springframework.transaction.annotation.EnableTransactionManagement;
 
-@Configuration
-@ConditionalOnClass(JDBCConfigProperties.class)
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(JDBCCatalogFacade.class)
 @ConditionalOnProperty(prefix = "geoserver.jdbcconfig", name = "enabled", matchIfMissing = true)
-@Import(JDBCConfigWebAutoConfiguration.class)
-@EnableTransactionManagement
+@Import({JDBCDataSourceConfiguration.class, JDBCConfigWebAutoConfiguration.class})
 public class JDBCConfigAutoConfiguration {
 
-    /**
-     * Extends {@link JDBCConfigProperties} to not need a {@link JDBCConfigPropertiesFactoryBean}
-     */
-    public static class CloudJdbcConfigProperties extends JDBCConfigProperties {
-        private static final long serialVersionUID = 1L;
-        private DataSource dataSource;
-
-        public CloudJdbcConfigProperties(DataSource dataSource) {
-            super((JDBCConfigPropertiesFactoryBean) null);
-            this.dataSource = dataSource;
-        }
-
-        /** Override to not save at all */
-        public @Override void save() throws IOException {
-            // factory.saveConfig(this);
-        }
-
-        /** Override to return {@code true} only if the db schema is not already created */
-        public @Override boolean isInitDb() {
-            //	        return Boolean.parseBoolean(getProperty("initdb", "false"));
-            boolean initDb = super.isInitDb();
-            if (initDb) {
-                try (Connection c = dataSource.getConnection();
-                        Statement st = c.createStatement()) {
-                    try {
-                        st.executeQuery("select * from object_property");
-                        initDb = false;
-                    } catch (SQLException e) {
-                        // table not found, proceed with initialization
-                    }
-                } catch (SQLException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-            return initDb;
-        }
-
-        /**
-         * Override to get the init script directly from the ones in the classpath (inside
-         * gs-jdbcconfig.jar)
-         */
-        public @Override Resource getInitScript() {
-            final String driverClassName = getProperty("datasource.driverClassname");
-            String scriptName;
-            switch (driverClassName) {
-                case "org.h2.Driver":
-                    scriptName = "initdb.h2.sql";
-                    break;
-                case "org.postgresql.Driver":
-                    scriptName = "initdb.postgres.sql";
-                    break;
-                default:
-                    scriptName = null;
-            }
-            if (scriptName == null) {
-                return null;
-            }
-            URL initScript = ConfigDatabase.class.getResource(scriptName);
-            Preconditions.checkState(
-                    initScript != null,
-                    "Init script does not exist: %s/%s",
-                    ConfigDatabase.class.getPackage().getName(),
-                    scriptName);
-
-            Resource resource = org.geoserver.platform.resource.URIs.asResource(initScript);
-            return resource;
-        }
-
-        public @Override Optional<String> getJdbcUrl() {
-            String url = getProperty("datasource.url");
-            if (null == url) {
-                url = getProperty("datasource.jdbcUrl");
-            }
-            return Optional.fromNullable(url);
-        }
-    }
-
-    //	  <!-- main configuration, loaded via factory bean -->
-    //	  <bean id="jdbcConfigProperties"
-    //	    class="org.geoserver.jdbcconfig.internal.JDBCConfigPropertiesFactoryBean">
-    //	      <constructor-arg ref="resourceStore"/>
-    //	  </bean>
+    // <!-- main configuration, loaded via factory bean -->
+    // <bean id="jdbcConfigProperties"
+    // class="org.geoserver.jdbcconfig.internal.JDBCConfigPropertiesFactoryBean">
+    // <constructor-arg ref="resourceStore"/>
+    // </bean>
     @ConfigurationProperties(prefix = "geoserver.jdbcconfig")
     public @Bean("JDBCConfigProperties") JDBCConfigProperties jdbcConfigProperties(
             @Qualifier("jdbcConfigDataSource") DataSource dataSource) {
-        JDBCConfigProperties props = new CloudJdbcConfigProperties(dataSource);
-        return props;
+        return new CloudJdbcConfigProperties(dataSource);
     }
 
-    //	  <!-- data source, also loaded and configured via factory bean -->
-    //	  <bean id="jdbcConfigDataSource" class="org.geoserver.jdbcloader.DataSourceFactoryBean">
-    //	    <constructor-arg ref="jdbcConfigProperties" />
-    //	  </bean>
-    @Bean
-    @ConfigurationProperties(prefix = "geoserver.jdbcconfig.datasource")
-    public DataSource jdbcConfigDataSource() {
-        return DataSourceBuilder.create().build();
-    }
-
-    //	  <!-- transaction manager -->
-    //	  <bean id="jdbcConfigTransactionManager"
-    //	  	class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
-    //	    <property name="dataSource" ref="jdbcConfigDataSource" />
-    //	  </bean>
-    //	  <tx:annotation-driven /> -> @EnableTransactionManagement above
-    @Bean
-    public DataSourceTransactionManager jdbcConfigTransactionManager() {
-        return new DataSourceTransactionManager(jdbcConfigDataSource());
-    }
-
-    //	  <bean id="jdbcPersistenceBinding"
+    // <bean id="jdbcPersistenceBinding"
     // class="org.geoserver.jdbcconfig.internal.XStreamInfoSerialBinding">
-    //	    <constructor-arg ref="xstreamPersisterFactory" />
-    //	  </bean>
+    // <constructor-arg ref="xstreamPersisterFactory" />
+    // </bean>
     public @Bean XStreamInfoSerialBinding jdbcPersistenceBinding(
             @Qualifier("xstreamPersisterFactory") XStreamPersisterFactory xstreamPersisterFactory) {
         return new XStreamInfoSerialBinding(xstreamPersisterFactory);
     }
 
-    //	  <bean id="JDBCConfigDB" class="org.geoserver.jdbcconfig.internal.ConfigDatabase">
-    //	    <constructor-arg ref="jdbcConfigDataSource" />
-    //	    <constructor-arg ref="jdbcPersistenceBinding" />
-    //	  </bean>
+    // <bean id="JDBCConfigDB"
+    // class="org.geoserver.jdbcconfig.internal.ConfigDatabase">
+    // <constructor-arg ref="jdbcConfigDataSource" />
+    // <constructor-arg ref="jdbcPersistenceBinding" />
+    // </bean>
     public @Bean(name = "JDBCConfigDB") ConfigDatabase jdbcConfigDB(
             @Qualifier("jdbcConfigDataSource") DataSource dataSource,
             XStreamInfoSerialBinding binding) {
         return new ConfigDatabase(dataSource, binding);
     }
 
-    //	  <bean id="JDBCCatalogFacade" class="org.geoserver.jdbcconfig.catalog.JDBCCatalogFacade">
-    //	    <constructor-arg ref="JDBCConfigDB" />
-    //	  </bean>
+    // <bean id="JDBCCatalogFacade"
+    // class="org.geoserver.jdbcconfig.catalog.JDBCCatalogFacade">
+    // <constructor-arg ref="JDBCConfigDB" />
+    // </bean>
     public @Bean(name = "JDBCCatalogFacade") JDBCCatalogFacade jdbcCatalogFacade(
             ConfigDatabase configDb) {
         return new JDBCCatalogFacade(configDb);
     }
 
-    //	  <bean id="JDBCGeoServerFacade" class="org.geoserver.jdbcconfig.config.JDBCGeoServerFacade">
-    //	    <constructor-arg ref="JDBCConfigDB" />
-    //	    <property name="resourceLoader" ref="resourceLoader" />
-    //	    <property name="ddResourceStore" ref="dataDirectoryResourceStore" />
-    //	  </bean>
+    // <bean id="JDBCGeoServerFacade"
+    // class="org.geoserver.jdbcconfig.config.JDBCGeoServerFacade">
+    // <constructor-arg ref="JDBCConfigDB" />
+    // <property name="resourceLoader" ref="resourceLoader" />
+    // <property name="ddResourceStore" ref="dataDirectoryResourceStore" />
+    // </bean>
     public @Bean("JDBCGeoServerFacade") JDBCGeoServerFacade jdbcGeoServerFacade(
             ConfigDatabase configDb,
             GeoServerResourceLoader resourceLoader,
@@ -192,16 +83,17 @@ public class JDBCConfigAutoConfiguration {
         return facade;
     }
 
-    //	  <bean id="JDBCGeoServerLoader" class="org.geoserver.jdbcconfig.JDBCGeoServerLoader">
-    //	    <description>
-    //	      Replaces the default GeoServerLoader to establish the JDBCCatalogFacade and
+    // <bean id="JDBCGeoServerLoader"
+    // class="org.geoserver.jdbcconfig.JDBCGeoServerLoader">
+    // <description>
+    // Replaces the default GeoServerLoader to establish the JDBCCatalogFacade and
     // JDBCGeoServerFacade
-    //	    </description>
-    //	    <constructor-arg ref="resourceLoader" />
-    //	    <constructor-arg ref="jdbcConfigProperties" />
-    //	    <property name="catalogFacade" ref="JDBCCatalogFacade" />
-    //	    <property name="geoServerFacade" ref="JDBCGeoServerFacade" />
-    //	  </bean>
+    // </description>
+    // <constructor-arg ref="resourceLoader" />
+    // <constructor-arg ref="jdbcConfigProperties" />
+    // <property name="catalogFacade" ref="JDBCCatalogFacade" />
+    // <property name="geoServerFacade" ref="JDBCGeoServerFacade" />
+    // </bean>
     public @Bean("JDBCGeoServerLoader") JDBCGeoServerLoader jdbcGeoServerLoader( //
             GeoServerResourceLoader resourceLoader, //
             JDBCConfigProperties config, //
@@ -215,12 +107,13 @@ public class JDBCConfigAutoConfiguration {
         return loader;
     }
 
-    //	  <bean id="JDBCCacheProvider" class="org.geoserver.jdbcconfig.internal.JDBCCacheProvider"/>
+    // <bean id="JDBCCacheProvider"
+    // class="org.geoserver.jdbcconfig.internal.JDBCCacheProvider"/>
     public @Bean("JDBCCacheProvider") JDBCCacheProvider jdbcCacheProvider() {
         return new JDBCCacheProvider();
     }
 
-    //	    <bean id="JDBCConfigXStreamPersisterInitializer"
+    // <bean id="JDBCConfigXStreamPersisterInitializer"
     // class="org.geoserver.jdbcconfig.internal.JDBCConfigXStreamPersisterInitializer"/>
     public @Bean("JDBCConfigXStreamPersisterInitializer") JDBCConfigXStreamPersisterInitializer
             jdbcConfigXStreamPersisterInitializer() {

--- a/services/catalog/src/main/java/org/geoserver/cloud/autoconfigure/jdbcconfig/JDBCDataSourceConfiguration.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/autoconfigure/jdbcconfig/JDBCDataSourceConfiguration.java
@@ -1,0 +1,44 @@
+package org.geoserver.cloud.autoconfigure.jdbcconfig;
+
+import javax.sql.DataSource;
+import org.geoserver.jdbcconfig.catalog.JDBCCatalogFacade;
+import org.geoserver.jdbcstore.JDBCResourceStore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * Configures the shared {@link DataSource} for {@link JDBCResourceStore} and {@link
+ * JDBCCatalogFacade}
+ */
+@Configuration
+@ConditionalOnProperty(prefix = "geoserver.jdbcconfig", name = "enabled", matchIfMissing = true)
+@EnableTransactionManagement
+public class JDBCDataSourceConfiguration {
+
+    // <!-- data source, also loaded and configured via factory bean -->
+    // <bean id="jdbcConfigDataSource"
+    // class="org.geoserver.jdbcloader.DataSourceFactoryBean">
+    // <constructor-arg ref="jdbcConfigProperties" />
+    // </bean>
+    @Bean(name = {"jdbcStoreDataSource", "jdbcConfigDataSource"})
+    @ConfigurationProperties(prefix = "geoserver.jdbcconfig.datasource")
+    public DataSource jdbcConfigDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    // <!-- transaction manager -->
+    // <bean id="jdbcConfigTransactionManager"
+    // class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    // <property name="dataSource" ref="jdbcConfigDataSource" />
+    // </bean>
+    // <tx:annotation-driven /> -> @EnableTransactionManagement above
+    @Bean
+    public DataSourceTransactionManager jdbcConfigTransactionManager() {
+        return new DataSourceTransactionManager(jdbcConfigDataSource());
+    }
+}

--- a/services/catalog/src/main/java/org/geoserver/cloud/autoconfigure/jdbcconfig/JDBCStoreAutoConfiguration.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/autoconfigure/jdbcconfig/JDBCStoreAutoConfiguration.java
@@ -1,15 +1,71 @@
 package org.geoserver.cloud.autoconfigure.jdbcconfig;
 
-import org.geoserver.jdbcconfig.internal.JDBCConfigProperties;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import javax.sql.DataSource;
+import org.geoserver.jdbcstore.JDBCResourceStore;
+import org.geoserver.jdbcstore.JDBCResourceStoreFactoryBean;
+import org.geoserver.jdbcstore.cache.SimpleResourceCache;
+import org.geoserver.jdbcstore.internal.JDBCResourceStoreProperties;
+import org.geoserver.platform.resource.DataDirectoryResourceStore;
+import org.geoserver.platform.resource.LockProvider;
+import org.geoserver.platform.resource.ResourceNotificationDispatcher;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ImportResource;
+import org.springframework.context.annotation.Import;
 
-@Configuration
-@ConditionalOnClass(JDBCConfigProperties.class)
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(JDBCResourceStore.class)
 @ConditionalOnProperty(prefix = "geoserver.jdbcconfig", name = "enabled", matchIfMissing = true)
-@ImportResource({
-    // "jar:file:/home/groldan/.m2/repository/org/geoserver/community/gs-jdbcstore/2.18-SNAPSHOT/gs-jdbcstore-2.18-SNAPSHOT.jar!/applicationContext.xml",//
-})
-public class JDBCStoreAutoConfiguration {}
+@Import(JDBCDataSourceConfiguration.class)
+public class JDBCStoreAutoConfiguration {
+    //	  <!-- main configuration, loaded via factory bean -->
+    //	  <bean id="jdbcStoreProperties"
+    //	    class="org.geoserver.jdbcstore.internal.JDBCResourceStorePropertiesFactoryBean">
+    //	      <constructor-arg ref="dataDirectoryResourceStore"/>
+    //	  </bean>
+    @ConfigurationProperties(prefix = "geoserver.jdbcconfig")
+    public @Bean JDBCResourceStoreProperties jdbcStoreProperties(
+            @Qualifier("jdbcConfigDataSource") DataSource dataSource) {
+        return new CloudJdbcStoreProperties(dataSource);
+    }
+
+    //	  <!-- cache -->
+    //	  <bean id="resourceCache" class="org.geoserver.jdbcstore.cache.DataDirectoryResourceCache">
+    //	  </bean>
+    //	public @Bean DataDirectoryResourceCache resourceCache() {
+    //		return new DataDirectoryResourceCache();
+    //	}
+
+    //	  <!-- resource store -->
+    //	  <bean id="resourceStoreImpl" class="org.geoserver.jdbcstore.JDBCResourceStoreFactoryBean">
+    //	    <constructor-arg ref="dataDirectoryResourceStore" />
+    //	    <constructor-arg ref="jdbcStoreDataSource" />
+    //	    <constructor-arg ref="jdbcStoreProperties" />
+    //	    <property name="cache" ref="resourceCache" />
+    //	    <property name="lockProvider" ref="lockProvider"/>
+    //	    <property name="resourceNotificationDispatcher" ref="resourceNotificationDispatcher"/>
+    //	  </bean>
+    public @Bean JDBCResourceStoreFactoryBean resourceStoreImpl( //
+            DataDirectoryResourceStore fallbackStore, //
+            @Qualifier("jdbcStoreDataSource") DataSource jdbcStoreDataSource, //
+            JDBCResourceStoreProperties config, //
+            LockProvider lockProvider, //
+            @Qualifier("resourceNotificationDispatcher")
+                    ResourceNotificationDispatcher resourceWatcher)
+            throws IOException {
+
+        JDBCResourceStoreFactoryBean fac =
+                new JDBCResourceStoreFactoryBean(fallbackStore, jdbcStoreDataSource, config);
+        File base = Files.createTempDirectory("geoserver.jdbcresource.cache").toFile();
+        fac.setCache(new SimpleResourceCache(base));
+        fac.setLockProvider(lockProvider);
+        fac.setResourceNotificationDispatcher(resourceWatcher);
+        return fac;
+    }
+}

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/GeoServerCatalogConfig.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/GeoServerCatalogConfig.java
@@ -4,10 +4,9 @@
  */
 package org.geoserver.cloud.catalog;
 
-import org.geoserver.cloud.autoconfigure.jdbcconfig.JDBCConfigAutoConfiguration;
+import org.geoserver.cloud.autoconfigure.EnableJdbcConfig;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 
 @Configuration
-@Import(JDBCConfigAutoConfiguration.class)
+@EnableJdbcConfig
 public class GeoServerCatalogConfig {}


### PR DESCRIPTION
Include JDBCStoreAutoConfiguration in GeoServerCatalogConfig overriding the bean definitions in `gs-jdbcscore-<version>.jar!/applicationContext.xml` with a java configuration in order to:

- share the java.sql.DataSource with jdbcconfig
- configure through spring properties (application.yml, etc)
- use a SimpleResourceCache with no data directory