### PR TITLE
Use spring-cloud-bus with rabbitmq to broadcast catalog change events

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,31 @@ networks:
     driver: bridge
         
 services:
+  rabbitmq:
+    image: rabbitmq:3-management
+    restart: always
+    environment:
+      RABBITMQ_DEFAULT_USER: "guest"
+      RABBITMQ_DEFAULT_PASS: "guest"
+    networks:
+      - gs-cloud-network
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+
+  database:
+    image: org.geoserver.cloud/gs-cloud-database:${TAG}
+    environment:
+      POSTGRES_DB: "${JDBCCONFIG_DBNAME}"
+      POSTGRES_USER: "${JDBCCONFIG_USERNAME}"
+      POSTGRES_PASSWORD: "${JDBCCONFIG_PASSWORD}"
+    ports:
+      - 5432:5432
+    networks:
+      - gs-cloud-network
+    volumes:
+      - postgresql_config_data:/var/lib/postgresql/data
+
   # Eureka service discovery. This is a Discovery First Bootstrap configuration.
   # The discovery service is the only fixed entry point.
   # Browse to http://localhost:8761 to check all services are registered.
@@ -38,6 +63,7 @@ services:
     environment:
       EUREKA_SERVER_URL: ${EUREKA_SERVER_URL}
       JAVA_OPTS: ${CONFIG_JAVA_OPTS}
+      RABBITMQ_HOST: rabbitmq
     networks:
       - gs-cloud-network
     healthcheck:
@@ -67,19 +93,6 @@ services:
     # wait until config service is available
     command: dockerize -wait http://config:8080/gateway-service/deafult --timeout 15s java ${GATEWAY_JAVA_OPTS} -jar /opt/app/gateway-service.jar
 
-  database:
-    image: org.geoserver.cloud/gs-cloud-database:${TAG}
-    environment:
-      POSTGRES_DB: "${JDBCCONFIG_DBNAME}"
-      POSTGRES_USER: "${JDBCCONFIG_USERNAME}"
-      POSTGRES_PASSWORD: "${JDBCCONFIG_PASSWORD}"
-    ports:
-      - 5432:5432
-    networks:
-      - gs-cloud-network
-    volumes:
-      - postgresql_config_data:/var/lib/postgresql/data
-
   # WFS microservice, port dynamically allocated to allow scaling (e.g docker-compose scale wfs=5)
   wfs:
     image: org.geoserver.cloud/gs-cloud-wfs:${TAG}
@@ -87,9 +100,11 @@ services:
       - discovery
       - config
       - database
+      - rabbitmq
     environment:
       EUREKA_SERVER_URL: ${EUREKA_SERVER_URL}
       JAVA_OPTS: ${WFS_JAVA_OPTS}
+      RABBITMQ_HOST: rabbitmq
       JDBCCONFIG_URL: "${JDBCCONFIG_URL}"
       JDBCCONFIG_USERNAME: "${JDBCCONFIG_USERNAME}"
       JDBCCONFIG_PASSWORD: "${JDBCCONFIG_PASSWORD}"
@@ -107,9 +122,12 @@ services:
     depends_on:
       - discovery
       - config
+      - database
+      - rabbitmq
     environment:
       EUREKA_SERVER_URL: ${EUREKA_SERVER_URL}
       JAVA_OPTS: ${WMS_JAVA_OPTS}
+      RABBITMQ_HOST: rabbitmq
       JDBCCONFIG_URL: "${JDBCCONFIG_URL}"
       JDBCCONFIG_USERNAME: "${JDBCCONFIG_USERNAME}"
       JDBCCONFIG_PASSWORD: "${JDBCCONFIG_PASSWORD}"
@@ -126,9 +144,12 @@ services:
     depends_on:
       - discovery
       - config
+      - database
+      - rabbitmq
     environment:
       EUREKA_SERVER_URL: ${EUREKA_SERVER_URL}
       JAVA_OPTS: ${WCS_JAVA_OPTS}
+      RABBITMQ_HOST: rabbitmq
       JDBCCONFIG_URL: "${JDBCCONFIG_URL}"
       JDBCCONFIG_USERNAME: "${JDBCCONFIG_USERNAME}"
       JDBCCONFIG_PASSWORD: "${JDBCCONFIG_PASSWORD}"
@@ -145,9 +166,12 @@ services:
     depends_on:
       - discovery
       - config
+      - database
+      - rabbitmq
     environment:
       EUREKA_SERVER_URL: ${EUREKA_SERVER_URL}
       JAVA_OPTS: ${WPS_JAVA_OPTS}
+      RABBITMQ_HOST: rabbitmq
       JDBCCONFIG_URL: "${JDBCCONFIG_URL}"
       JDBCCONFIG_USERNAME: "${JDBCCONFIG_USERNAME}"
       JDBCCONFIG_PASSWORD: "${JDBCCONFIG_PASSWORD}"
@@ -164,9 +188,12 @@ services:
     depends_on:
       - discovery
       - config
+      - database
+      - rabbitmq
     environment:
       EUREKA_SERVER_URL: ${EUREKA_SERVER_URL}
       JAVA_OPTS: ${REST_JAVA_OPTS}
+      RABBITMQ_HOST: rabbitmq
       JDBCCONFIG_URL: "${JDBCCONFIG_URL}"
       JDBCCONFIG_USERNAME: "${JDBCCONFIG_USERNAME}"
       JDBCCONFIG_PASSWORD: "${JDBCCONFIG_PASSWORD}"

--- a/services/catalog/pom.xml
+++ b/services/catalog/pom.xml
@@ -20,6 +20,14 @@
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-bus-amqp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/services/catalog/src/main/java/org/geoserver/cloud/autoconfigure/EnableBusEventHandling.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/autoconfigure/EnableBusEventHandling.java
@@ -1,0 +1,16 @@
+package org.geoserver.cloud.autoconfigure;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.geoserver.cloud.catalog.bus.BusDisabledLogger;
+import org.geoserver.cloud.catalog.bus.CatalogBusAutoConfiguration;
+import org.springframework.context.annotation.Import;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Documented
+@Import({CatalogBusAutoConfiguration.class, BusDisabledLogger.class})
+public @interface EnableBusEventHandling {}

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/GeoServerCatalogConfig.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/GeoServerCatalogConfig.java
@@ -4,9 +4,13 @@
  */
 package org.geoserver.cloud.catalog;
 
+import org.geoserver.cloud.autoconfigure.EnableBusEventHandling;
 import org.geoserver.cloud.autoconfigure.EnableJdbcConfig;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@EnableAutoConfiguration
 @EnableJdbcConfig
+@EnableBusEventHandling
 public class GeoServerCatalogConfig {}

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/bus/BusDisabledLogger.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/bus/BusDisabledLogger.java
@@ -1,0 +1,18 @@
+package org.geoserver.cloud.catalog.bus;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.bus.ConditionalOnBusEnabled;
+
+@Slf4j
+@ConditionalOnProperty(
+    value = ConditionalOnBusEnabled.SPRING_CLOUD_BUS_ENABLED,
+    matchIfMissing = false,
+    havingValue = "false"
+)
+public class BusDisabledLogger {
+
+    public BusDisabledLogger() {
+        log.warn("GeoServer Catalog and configuration event-bus is disabled");
+    }
+}

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/bus/CatalogBusAutoConfiguration.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/bus/CatalogBusAutoConfiguration.java
@@ -1,0 +1,41 @@
+package org.geoserver.cloud.catalog.bus;
+
+import javax.annotation.PostConstruct;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.cloud.catalog.bus.events.CatalogRemoteEvent;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.cloud.bus.BusAutoConfiguration;
+import org.springframework.cloud.bus.BusProperties;
+import org.springframework.cloud.bus.ConditionalOnBusEnabled;
+import org.springframework.cloud.bus.jackson.RemoteApplicationEventScan;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnBusEnabled
+@AutoConfigureAfter(BusAutoConfiguration.class)
+@RemoteApplicationEventScan(basePackageClasses = CatalogRemoteEvent.class)
+@Slf4j
+public class CatalogBusAutoConfiguration {
+
+    public CatalogBusAutoConfiguration() {}
+
+    private @PostConstruct void logInit() {
+        log.info("Configuring GeoServer Catalog distributed events");
+    }
+
+    public @Bean CatalogRemoteEventBroadcaster catalogRemoteEventBroadcaster(
+            @NonNull BusProperties busProperties, @Qualifier("rawCatalog") Catalog rawCatalog) {
+        CatalogRemoteEventBroadcaster broadcaster = new CatalogRemoteEventBroadcaster();
+        rawCatalog.addListener(broadcaster);
+        return broadcaster;
+    }
+
+    public @Bean CatalogRemoteEventProcessor catalogRemoteEventProcessor(
+            @Qualifier("rawCatalog") Catalog rawCatalog) {
+        return new CatalogRemoteEventProcessor(rawCatalog);
+    }
+}

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/bus/CatalogRemoteEventBroadcaster.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/bus/CatalogRemoteEventBroadcaster.java
@@ -1,0 +1,113 @@
+package org.geoserver.cloud.catalog.bus;
+
+import lombok.extern.slf4j.Slf4j;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogException;
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.event.CatalogAddEvent;
+import org.geoserver.catalog.event.CatalogEvent;
+import org.geoserver.catalog.event.CatalogListener;
+import org.geoserver.catalog.event.CatalogModifyEvent;
+import org.geoserver.catalog.event.CatalogPostModifyEvent;
+import org.geoserver.catalog.event.CatalogRemoveEvent;
+import org.geoserver.catalog.impl.ClassMappings;
+import org.geoserver.catalog.impl.ModificationProxy;
+import org.geoserver.cloud.catalog.bus.events.CatalogRemoteAddEvent;
+import org.geoserver.cloud.catalog.bus.events.CatalogRemoteEvent;
+import org.geoserver.cloud.catalog.bus.events.CatalogRemoteModifyEvent;
+import org.geoserver.cloud.catalog.bus.events.CatalogRemoteRemoveEvent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.bus.BusAutoConfiguration;
+import org.springframework.cloud.bus.BusProperties;
+import org.springframework.cloud.bus.event.RemoteApplicationEvent;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
+
+/**
+ * Listens to {@link CatalogEvent catalog events} produced by this service instance and broadcasts
+ * them to the cluster as {@link CatalogRemoteEvent catalog remote events}
+ *
+ * <p>GeoServer {@link Catalog} does not publish spring {@link ApplicationEvent}s, but {@link
+ * CatalogEvent}s to the {@link CatalogListener}s in the spring context. This {@code
+ * CatalogListener} takes those events when changes to the catalog are performed on this instance
+ * and publishes them to the cluster event bus.
+ */
+@Slf4j
+public class CatalogRemoteEventBroadcaster implements CatalogListener {
+
+    /** The event publisher, usually the {@link ApplicationContext} itself */
+    private @Autowired ApplicationEventPublisher eventPublisher;
+
+    /**
+     * Properties shared with {@link BusAutoConfiguration} in order to get the {@link
+     * BusProperties#getId() service-id} used to identify the origin of {@link
+     * RemoteApplicationEvent remote-events}. Such events ought to be constructed with that service
+     * id to be properly broadcasted to other nodes but ignored on the sending node.
+     */
+    private @Autowired BusProperties busProperties;
+
+    private void publishRemoteEvent(CatalogRemoteEvent remoteEvent) {
+        log.info("broadcasting remote event {}", remoteEvent);
+        eventPublisher.publishEvent(remoteEvent);
+    }
+
+    public @Override void handleAddEvent(CatalogAddEvent event) throws CatalogException {
+        String originService = busProperties.getId();
+        String destinationService = null; // all services
+        String catalogInfoId = event.getSource().getId();
+        ClassMappings catalogInfoEnumType = interfaceOf(event.getSource());
+        publishRemoteEvent(
+                new CatalogRemoteAddEvent(
+                        this,
+                        originService,
+                        destinationService,
+                        catalogInfoId,
+                        catalogInfoEnumType));
+    }
+
+    public @Override void handleRemoveEvent(CatalogRemoveEvent event) throws CatalogException {
+        String originService = busProperties.getId();
+        String destinationService = null; // all services
+        String catalogInfoId = event.getSource().getId();
+        ClassMappings catalogInfoEnumType = interfaceOf(event.getSource());
+        publishRemoteEvent(
+                new CatalogRemoteRemoveEvent(
+                        this,
+                        originService,
+                        destinationService,
+                        catalogInfoId,
+                        catalogInfoEnumType));
+    }
+
+    public @Override void handlePostModifyEvent(CatalogPostModifyEvent event)
+            throws CatalogException {
+        String originService = busProperties.getId();
+        String destinationService = null; // all services
+        String catalogInfoId = event.getSource().getId();
+        ClassMappings catalogInfoEnumType = interfaceOf(event.getSource());
+        publishRemoteEvent(
+                new CatalogRemoteModifyEvent(
+                        this,
+                        originService,
+                        destinationService,
+                        catalogInfoId,
+                        catalogInfoEnumType));
+    }
+
+    private ClassMappings interfaceOf(CatalogInfo source) {
+        source = ModificationProxy.unwrap(source);
+        ClassMappings mappings = ClassMappings.fromImpl(source.getClass());
+        return mappings;
+    }
+
+    /** no-op, we only need to broadcast {@link CatalogPostModifyEvent post-modification} events */
+    public @Override void handleModifyEvent(CatalogModifyEvent event) throws CatalogException {
+        // no-op
+    }
+
+    /** no-op */
+    public @Override void reloaded() {
+        // no-op
+    }
+}

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/bus/CatalogRemoteEventProcessor.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/bus/CatalogRemoteEventProcessor.java
@@ -1,0 +1,150 @@
+package org.geoserver.cloud.catalog.bus;
+
+import java.lang.reflect.Proxy;
+import lombok.extern.slf4j.Slf4j;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.CoverageStoreInfo;
+import org.geoserver.catalog.DataStoreInfo;
+import org.geoserver.catalog.FeatureTypeInfo;
+import org.geoserver.catalog.ResourcePool;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WMSStoreInfo;
+import org.geoserver.catalog.WMTSStoreInfo;
+import org.geoserver.catalog.impl.ClassMappings;
+import org.geoserver.cloud.catalog.bus.events.CatalogRemoteAddEvent;
+import org.geoserver.cloud.catalog.bus.events.CatalogRemoteEvent;
+import org.geoserver.cloud.catalog.bus.events.CatalogRemoteModifyEvent;
+import org.geoserver.cloud.catalog.bus.events.CatalogRemoteRemoveEvent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.bus.BusAutoConfiguration;
+import org.springframework.cloud.bus.ServiceMatcher;
+import org.springframework.cloud.bus.event.AckRemoteApplicationEvent;
+import org.springframework.cloud.bus.event.RemoteApplicationEvent;
+import org.springframework.context.event.EventListener;
+
+/**
+ * Listens to {@link CatalogRemoteEvent}s and acts accordingly
+ *
+ * @implNote {@code spring-cloud-bus} builds an abstraction layer over {@code spring-cloud-stream}
+ *     to set up the event bus for the microservices on top of the configured broker (AMQP/Kafka),
+ *     handling. See {@link BusAutoConfiguration}, it sets up the bus configuration and makes sure
+ *     {@link RemoteApplicationEvent}s are not published to the same instance that broadcast them.
+ */
+@Slf4j
+public class CatalogRemoteEventProcessor {
+
+    private Catalog rawCatalog;
+
+    private @Autowired ServiceMatcher busServiceMatcher;
+
+    public @Autowired CatalogRemoteEventProcessor(Catalog rawCatalog) {
+        this.rawCatalog = rawCatalog;
+    }
+
+    /**
+     * Logs ack events received from nodes which processed events sent by the remote event
+     * broadcaster
+     *
+     * <p>{@code spring.cloud.bus.ack.enabled=true} must be set in order for these events to be
+     * processed (see {@link BusAutoConfiguration})
+     */
+    public @EventListener(AckRemoteApplicationEvent.class) void ackReceived(
+            AckRemoteApplicationEvent event) {
+        if (!busServiceMatcher.isFromSelf(event)) {
+            log.debug("Received event ack {}", event); // TODO improve log statement
+        }
+    }
+
+    /**
+     * no-op, really, what do we care if a CatalogInfo has been added until anincoming service
+     * request needs it
+     */
+    @EventListener(CatalogRemoteAddEvent.class)
+    public void onCatalogRemoteAddEvent(CatalogRemoteAddEvent event) {
+        if (busServiceMatcher.isFromSelf(event)) {
+            log.debug("Ignoring remote event from self: {}", event);
+        } else {
+            log.debug("remote add event, nothing to do. {}", event);
+        }
+    }
+
+    @EventListener(CatalogRemoteRemoveEvent.class)
+    public void onCatalogRemoteRemoveEvent(CatalogRemoteRemoveEvent event) {
+        evictFromResourcePool(event);
+    }
+
+    @EventListener(CatalogRemoteModifyEvent.class)
+    public void onCatalogRemoteModifyEvent(CatalogRemoteModifyEvent event) {
+        evictFromResourcePool(event);
+    }
+
+    private void evictFromResourcePool(CatalogRemoteEvent event) {
+        if (busServiceMatcher.isFromSelf(event)) {
+            log.debug("Ignoring remote event from self: {}", event);
+            return;
+        }
+        log.debug("handling remote event: {}", event);
+
+        final String id = event.getCatalogInfoId();
+        final ClassMappings catalogInfoEnumType = event.getCatalogInfoEnumType();
+        switch (catalogInfoEnumType) {
+            case COVERAGESTORE:
+            case DATASTORE:
+            case FEATURETYPE:
+            case STYLE:
+            case WMSSTORE:
+            case WMTSSTORE:
+                doEvict(id, catalogInfoEnumType);
+                break;
+            default:
+                log.debug(
+                        "no need to clear resource pool cache entry for object of type {}",
+                        catalogInfoEnumType);
+                break;
+        }
+    }
+
+    private void doEvict(String id, ClassMappings catalogInfoEnumType) {
+        log.debug("Evicting resource pool cache entry id: {}, type: {}", id, catalogInfoEnumType);
+        final Class<? extends CatalogInfo> catalogInfoType = catalogInfoEnumType.getInterface();
+        ResourcePool resourcePool = rawCatalog.getResourcePool();
+        CatalogInfo catalogInfo = proxyInstanceOf(id, catalogInfoType);
+        switch (catalogInfoEnumType) {
+            case COVERAGESTORE:
+                resourcePool.clear((CoverageStoreInfo) catalogInfo);
+                break;
+            case DATASTORE:
+                resourcePool.clear((DataStoreInfo) catalogInfo);
+                break;
+            case FEATURETYPE:
+                resourcePool.clear((FeatureTypeInfo) catalogInfo);
+                break;
+            case STYLE:
+                resourcePool.clear((StyleInfo) catalogInfo);
+                break;
+            case WMSSTORE:
+                resourcePool.clear((WMSStoreInfo) catalogInfo);
+                break;
+            case WMTSSTORE:
+                resourcePool.clear((WMTSStoreInfo) catalogInfo);
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    private CatalogInfo proxyInstanceOf(
+            final String id, final Class<? extends CatalogInfo> catalogInfoType) {
+        return (CatalogInfo)
+                Proxy.newProxyInstance(
+                        getClass().getClassLoader(),
+                        new Class[] {catalogInfoType},
+                        (proxy, method, args) -> {
+                            if (method.getName().equals("getId")) {
+                                return id;
+                            }
+                            return null;
+                        });
+    }
+}

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/bus/events/CatalogRemoteAddEvent.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/bus/events/CatalogRemoteAddEvent.java
@@ -1,0 +1,25 @@
+package org.geoserver.cloud.catalog.bus.events;
+
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import lombok.ToString;
+import org.geoserver.catalog.impl.ClassMappings;
+
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class CatalogRemoteAddEvent extends CatalogRemoteEvent {
+    private static final long serialVersionUID = 1L;
+
+    protected CatalogRemoteAddEvent() {
+        // default constructor, needed for deserialization
+    }
+
+    public CatalogRemoteAddEvent(
+            Object source,
+            String originService,
+            String destinationService,
+            @NonNull String catalogInfoId,
+            @NonNull ClassMappings catalogInfoEnumType) {
+        super(source, originService, destinationService, catalogInfoId, catalogInfoEnumType);
+    }
+}

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/bus/events/CatalogRemoteEvent.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/bus/events/CatalogRemoteEvent.java
@@ -1,0 +1,35 @@
+package org.geoserver.cloud.catalog.bus.events;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.impl.ClassMappings;
+import org.springframework.cloud.bus.event.RemoteApplicationEvent;
+
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public abstract class CatalogRemoteEvent extends RemoteApplicationEvent {
+    private static final long serialVersionUID = 1L;
+
+    /** Identifier of the catalog object this event refers to, from {@link CatalogInfo#getId()} */
+    private @Getter String catalogInfoId;
+
+    private @Getter ClassMappings catalogInfoEnumType;
+
+    protected CatalogRemoteEvent() {
+        // default constructor, needed for deserialization
+    }
+
+    protected CatalogRemoteEvent(
+            Object source,
+            String originService,
+            String destinationService,
+            @NonNull String catalogInfoId,
+            @NonNull ClassMappings catalogInfoEnumType) {
+        super(source, originService, destinationService);
+        this.catalogInfoId = catalogInfoId;
+        this.catalogInfoEnumType = catalogInfoEnumType;
+    }
+}

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/bus/events/CatalogRemoteModifyEvent.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/bus/events/CatalogRemoteModifyEvent.java
@@ -1,0 +1,26 @@
+package org.geoserver.cloud.catalog.bus.events;
+
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import lombok.ToString;
+import org.geoserver.catalog.impl.ClassMappings;
+
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class CatalogRemoteModifyEvent extends CatalogRemoteEvent {
+    private static final long serialVersionUID = 1L;
+
+    /** default constructor, needed for deserialization */
+    protected CatalogRemoteModifyEvent() {
+        //
+    }
+
+    public CatalogRemoteModifyEvent(
+            Object source,
+            String originService,
+            String destinationService,
+            @NonNull String catalogInfoId,
+            @NonNull ClassMappings catalogInfoEnumType) {
+        super(source, originService, destinationService, catalogInfoId, catalogInfoEnumType);
+    }
+}

--- a/services/catalog/src/main/java/org/geoserver/cloud/catalog/bus/events/CatalogRemoteRemoveEvent.java
+++ b/services/catalog/src/main/java/org/geoserver/cloud/catalog/bus/events/CatalogRemoteRemoveEvent.java
@@ -1,0 +1,24 @@
+package org.geoserver.cloud.catalog.bus.events;
+
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import lombok.ToString;
+import org.geoserver.catalog.impl.ClassMappings;
+
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class CatalogRemoteRemoveEvent extends CatalogRemoteEvent {
+    private static final long serialVersionUID = 1L;
+
+    /** default constructor, needed for deserialization */
+    protected CatalogRemoteRemoveEvent() {}
+
+    public CatalogRemoteRemoveEvent(
+            Object source,
+            String originService,
+            String destinationService,
+            @NonNull String catalogInfoId,
+            @NonNull ClassMappings catalogInfoEnumType) {
+        super(source, originService, destinationService, catalogInfoId, catalogInfoEnumType);
+    }
+}

--- a/services/catalog/src/main/resources/spring.factories
+++ b/services/catalog/src/main/resources/spring.factories
@@ -1,3 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.geoserver.cloud.autoconfigure.jdbcconfig.JDBCConfigAutoConfiguration,\
-org.geoserver.cloud.autoconfigure.jdbcconfig.JDBCStoreAutoConfiguration
+org.geoserver.cloud.autoconfigure.jdbcconfig.JDBCStoreAutoConfiguration,\
+org.geoserver.cloud.catalog.bus.CatalogBusAutoConfiguration,\
+org.geoserver.cloud.catalog.bus.BusDisabledLogger

--- a/services/restconfig/src/main/resources/bootstrap-local.yml
+++ b/services/restconfig/src/main/resources/bootstrap-local.yml
@@ -1,0 +1,8 @@
+server.port: 9092
+jdbcconfig.url: jdbc:postgresql://database:5432/geoserver_config
+jdbcconfig.username: geoserver
+jdbcconfig.password: geo$erver
+
+logging:
+  level:
+    org.geoserver.cloud.catalog.bus: DEBUG

--- a/services/restconfig/src/main/resources/bootstrap.yml
+++ b/services/restconfig/src/main/resources/bootstrap.yml
@@ -1,5 +1,6 @@
 server:
   port: 8080
+  instance-id: ${spring.application.name}:${spring.application.instance_id:${spring.cloud.client.ip-address}}:${server.port}
   servlet:
     context-path: /
 spring:
@@ -16,11 +17,12 @@ spring:
       discovery:
         enabled: true
         service-id: config-service
+
 eureka:
   instance:
     hostname: ${spring.application.name}
+    instance-id: ${server.instance-id}
     preferIpAddress: true
-    instance-id: ${spring.application.name}:${spring.application.instance_id:${spring.cloud.client.ip-address}}:${server.port}
     lease-expiration-duration-in-seconds: 30
     lease-renewal-interval-in-seconds: 30
   client:

--- a/services/wcs/src/main/resources/bootstrap.yml
+++ b/services/wcs/src/main/resources/bootstrap.yml
@@ -1,5 +1,6 @@
 server:
   port: 8080
+  instance-id: ${spring.application.name}:${spring.application.instance_id:${spring.cloud.client.ip-address}}:${server.port}
   servlet:
     context-path: /
 spring:
@@ -19,8 +20,8 @@ spring:
 eureka:
   instance:
     hostname: ${spring.application.name}
+    instance-id: ${server.instance-id}
     preferIpAddress: true
-    instance-id: ${spring.application.name}:${spring.application.instance_id:${spring.cloud.client.ip-address}}:${server.port}
     lease-expiration-duration-in-seconds: 30
     lease-renewal-interval-in-seconds: 30
   client:

--- a/services/wfs/src/main/resources/application-bus.yml
+++ b/services/wfs/src/main/resources/application-bus.yml
@@ -1,0 +1,9 @@
+spring:
+   cloud:
+      bus:
+        enabled: true
+      rabbitmq:
+        host: ${RABBITMQ_HOST:localhost}
+        port: ${RABBITMQ_PORT:5672}
+        username: ${RABBITMQ_URSER:guest}
+        password: ${RABBITMQ_PASSWORD:guest}

--- a/services/wfs/src/main/resources/bootstrap-local.yml
+++ b/services/wfs/src/main/resources/bootstrap-local.yml
@@ -1,0 +1,8 @@
+server.port: 9091
+jdbcconfig.url: jdbc:postgresql://database:5432/geoserver_config
+jdbcconfig.username: geoserver
+jdbcconfig.password: geo$erver
+
+logging:
+  level:
+    org.geoserver.cloud.catalog.bus: DEBUG

--- a/services/wfs/src/main/resources/bootstrap.yml
+++ b/services/wfs/src/main/resources/bootstrap.yml
@@ -1,5 +1,6 @@
 server:
   port: 8080
+  instance-id: ${spring.application.name}:${spring.application.instance_id:${spring.cloud.client.ip-address}}:${server.port}
   servlet:
     context-path: /
 spring:
@@ -19,8 +20,8 @@ spring:
 eureka:
   instance:
     hostname: ${spring.application.name}
+    instance-id: ${server.instance-id}
     preferIpAddress: true
-    instance-id: ${spring.application.name}:${spring.application.instance_id:${spring.cloud.client.ip-address}}:${server.port}
     lease-expiration-duration-in-seconds: 30
     lease-renewal-interval-in-seconds: 30
   client:

--- a/services/wms/src/main/resources/bootstrap.yml
+++ b/services/wms/src/main/resources/bootstrap.yml
@@ -1,5 +1,6 @@
 server:
   port: 8080
+  instance-id: ${spring.application.name}:${spring.application.instance_id:${spring.cloud.client.ip-address}}:${server.port}
   servlet:
     context-path: /
 spring:
@@ -19,8 +20,8 @@ spring:
 eureka:
   instance:
     hostname: ${spring.application.name}
+    instance-id: ${server.instance-id}
     preferIpAddress: true
-    instance-id: ${spring.application.name}:${spring.application.instance_id:${spring.cloud.client.ip-address}}:${server.port}
     lease-expiration-duration-in-seconds: 30
     lease-renewal-interval-in-seconds: 30
   client:

--- a/services/wps/src/main/resources/bootstrap.yml
+++ b/services/wps/src/main/resources/bootstrap.yml
@@ -1,5 +1,6 @@
 server:
   port: 8080
+  instance-id: ${spring.application.name}:${spring.application.instance_id:${spring.cloud.client.ip-address}}:${server.port}
   servlet:
     context-path: /
 spring:
@@ -19,8 +20,8 @@ spring:
 eureka:
   instance:
     hostname: ${spring.application.name}
+    instance-id: ${server.instance-id}
     preferIpAddress: true
-    instance-id: ${spring.application.name}:${spring.application.instance_id:${spring.cloud.client.ip-address}}:${server.port}
     lease-expiration-duration-in-seconds: 30
     lease-renewal-interval-in-seconds: 30
   client:

--- a/support-services/api-gateway/src/main/resources/bootstrap.yml
+++ b/support-services/api-gateway/src/main/resources/bootstrap.yml
@@ -1,5 +1,6 @@
 server:
   port: 8080
+  instance-id: ${spring.application.name}:${spring.application.instance_id:${spring.cloud.client.ip-address}}:${server.port}
 spring:
   main:
     banner-mode: off
@@ -16,8 +17,8 @@ spring:
 eureka:
   instance:
     hostname: ${spring.application.name}
+    instance-id: ${server.instance-id}
     preferIpAddress: true
-    instance-id: ${spring.application.name}:${spring.application.instance_id:${spring.cloud.client.ip-address}}:${server.port}
     lease-expiration-duration-in-seconds: 30
     lease-renewal-interval-in-seconds: 30
   client:

--- a/support-services/config/src/main/resources/bootstrap.yml
+++ b/support-services/config/src/main/resources/bootstrap.yml
@@ -1,5 +1,7 @@
 server:
   port: 8080
+  instance-id: ${spring.application.name}:${spring.application.instance_id:${spring.cloud.client.ip-address}}:${server.port}
+
 spring:
   main:
     banner-mode: off
@@ -10,8 +12,8 @@ spring:
 eureka:
   instance:
     hostname: ${spring.application.name}
+    instance-id: ${server.instance-id}
     preferIpAddress: true
-    instance-id: ${spring.application.name}:${spring.application.instance_id:${spring.cloud.client.ip-address}}:${server.port}
     lease-expiration-duration-in-seconds: 30
     lease-renewal-interval-in-seconds: 30
   client:

--- a/support-services/config/src/main/resources/config/restconfig-v1.yml
+++ b/support-services/config/src/main/resources/config/restconfig-v1.yml
@@ -6,9 +6,30 @@ geoserver:
       username: ${jdbcconfig.username:postgres}
       password: ${jdbcconfig.password:s3cr3t}
       driverClassname: ${jdbcconfig.driverClassname:org.postgresql.Driver}
+
+spring:
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_URSER:guest}
+    password: ${RABBITMQ_PASSWORD:guest}
+  cloud:
+    bus:
+      enabled: true
+      id: ${server.instance-id} # use the same instance id for eureka (see service's' bootstrap.yml) and cloud-bus' rabbitmq instance id
+      trace.enabled: true #switch on tracing of acks (default off).
+    stream:
+      bindings:
+        springCloudBusOutput:
+          destination: geoserver
+        springCloudBusInput:
+          destination: geoserver
+          group: catalog-event-queue
+
 logging:
   level:
-    org.springframework: ERROR
+#      org.springframework: ERROR
+    org.geoserver.cloud: DEBUG
     oshi.hardware.platform.linux: OFF
     org.geoserver.jdbcconfig: INFO
     org.geoserver.jdbcconfig.internal: INFO

--- a/support-services/config/src/main/resources/config/wcs-service.yml
+++ b/support-services/config/src/main/resources/config/wcs-service.yml
@@ -6,9 +6,30 @@ geoserver:
       username: ${jdbcconfig.username:postgres}
       password: ${jdbcconfig.password:s3cr3t}
       driverClassname: ${jdbcconfig.driverClassname:org.postgresql.Driver}
+
+spring:
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_URSER:guest}
+    password: ${RABBITMQ_PASSWORD:guest}
+  cloud:
+    bus:
+      enabled: true
+      id: ${server.instance-id} # use the same instance id for eureka (see service's' bootstrap.yml) and cloud-bus' rabbitmq instance id
+      trace.enabled: true #switch on tracing of acks (default off).
+    stream:
+      bindings:
+        springCloudBusOutput:
+          destination: geoserver
+        springCloudBusInput:
+          destination: geoserver
+          group: catalog-event-queue
+
 logging:
   level:
-    org.springframework: ERROR
+#    org.springframework: ERROR
+    org.geoserver.cloud: DEBUG
     oshi.hardware.platform.linux: OFF
     org.geoserver.jdbcconfig: INFO
     org.geoserver.jdbcconfig.internal: INFO

--- a/support-services/config/src/main/resources/config/wfs-service.yml
+++ b/support-services/config/src/main/resources/config/wfs-service.yml
@@ -6,9 +6,30 @@ geoserver:
       username: ${jdbcconfig.username:postgres}
       password: ${jdbcconfig.password:s3cr3t}
       driverClassname: ${jdbcconfig.driverClassname:org.postgresql.Driver}
+
+spring:
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_URSER:guest}
+    password: ${RABBITMQ_PASSWORD:guest}
+  cloud:
+    bus:
+      enabled: true
+      id: ${server.instance-id} # use the same instance id for eureka (see service's' bootstrap.yml) and cloud-bus' rabbitmq instance id
+      trace.enabled: true #switch on tracing of acks (default off).
+    stream:
+      bindings:
+        springCloudBusOutput:
+          destination: geoserver
+        springCloudBusInput:
+          destination: geoserver
+          group: catalog-event-queue
+
 logging:
   level:
-    org.springframework: ERROR
+#      org.springframework: ERROR
+    org.geoserver.cloud: DEBUG
     oshi.hardware.platform.linux: OFF
     org.geoserver.jdbcconfig: INFO
     org.geoserver.jdbcconfig.internal: INFO

--- a/support-services/config/src/main/resources/config/wms-service.yml
+++ b/support-services/config/src/main/resources/config/wms-service.yml
@@ -6,9 +6,30 @@ geoserver:
       username: ${jdbcconfig.username:postgres}
       password: ${jdbcconfig.password:s3cr3t}
       driverClassname: ${jdbcconfig.driverClassname:org.postgresql.Driver}
+
+spring:
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_URSER:guest}
+    password: ${RABBITMQ_PASSWORD:guest}
+  cloud:
+    bus:
+      enabled: true
+      id: ${server.instance-id} # use the same instance id for eureka (see service's' bootstrap.yml) and cloud-bus' rabbitmq instance id
+      trace.enabled: true #switch on tracing of acks (default off).
+    stream:
+      bindings:
+        springCloudBusOutput:
+          destination: geoserver
+        springCloudBusInput:
+          destination: geoserver
+          group: catalog-event-queue
+
 logging:
   level:
-    org.springframework: ERROR
+#    org.springframework: ERROR
+    org.geoserver.cloud: DEBUG
     oshi.hardware.platform.linux: OFF
     org.geoserver.jdbcconfig: INFO
     org.geoserver.jdbcconfig.internal: INFO

--- a/support-services/config/src/main/resources/config/wps-service.yml
+++ b/support-services/config/src/main/resources/config/wps-service.yml
@@ -6,9 +6,30 @@ geoserver:
       username: ${jdbcconfig.username:postgres}
       password: ${jdbcconfig.password:s3cr3t}
       driverClassname: ${jdbcconfig.driverClassname:org.postgresql.Driver}
+
+spring:
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_URSER:guest}
+    password: ${RABBITMQ_PASSWORD:guest}
+  cloud:
+    bus:
+      enabled: true
+      id: ${server.instance-id} # use the same instance id for eureka (see service's' bootstrap.yml) and cloud-bus' rabbitmq instance id
+      trace.enabled: true #switch on tracing of acks (default off).
+    stream:
+      bindings:
+        springCloudBusOutput:
+          destination: geoserver
+        springCloudBusInput:
+          destination: geoserver
+          group: catalog-event-queue
+
 logging:
   level:
-    org.springframework: ERROR
+#    org.springframework: ERROR
+    org.geoserver.cloud: DEBUG
     oshi.hardware.platform.linux: OFF
     org.geoserver.jdbcconfig: INFO
     org.geoserver.jdbcconfig.internal: INFO


### PR DESCRIPTION
`spring-cloud-bus` provides an appropriate abstraction layer on top of a
distributed events broker (using `spring-cloud-stream` to set up the
transport layer).

This patch adds a `rabbitmq` service to the docker composition and
configures a `geoserver.catalog-events-queue` event queue to communicate
catalog changes to all microservices so they clear up their locally
cached version of the modified or deleted catalog objects (see
[CatalogRemoteEventBroadcaster](https://github.com/camptocamp/geoserver-microservices/pull/7/files#diff-bd52b82a4079584e5368a77cdd90b0f5R37) and [CatalogRemoteEventProcessor](https://github.com/camptocamp/geoserver-microservices/pull/7/files#diff-f231d5c15a8f8da475069d6160eb7858R35)).