### PR TITLE
Fix FilteringXmlBeanDefinitionReader and cleaner semantics

### DIFF
--- a/config/wfs-service.yml
+++ b/config/wfs-service.yml
@@ -49,6 +49,7 @@ logging:
     org.springframework.cloud.bus: INFO
     org.geoserver.platform: ERROR
     org.geoserver.cloud: INFO
+    org.geoserver.cloud.config.factory: DEBUG
     org.geoserver.cloud.catalog.bus: DEBUG
     org.geoserver.cloud.autoconfigure: INFO
     org.geoserver.jdbcconfig: INFO

--- a/config/wms-service.yml
+++ b/config/wms-service.yml
@@ -49,6 +49,7 @@ logging:
     org.springframework.cloud.bus: INFO
     org.geoserver.platform: ERROR
     org.geoserver.cloud: INFO
+    org.geoserver.cloud.config.factory: DEBUG
     org.geoserver.cloud.autoconfigure: INFO
     org.geoserver.cloud.catalog.bus: DEBUG
     org.geoserver.jdbcconfig: INFO

--- a/config/wps-service.yml
+++ b/config/wps-service.yml
@@ -48,6 +48,7 @@ logging:
     org.springframework: ERROR
     org.springframework.cloud.bus: INFO
     org.geoserver.cloud: INFO
+    org.geoserver.cloud.config.factory: DEBUG
     org.geoserver.cloud.catalog.bus: DEBUG
     org.geoserver.cloud.autoconfigure: INFO
     org.geoserver.jdbcconfig: INFO

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <gs.version>2.18-SNAPSHOT</gs.version>
     <fmt.action>format</fmt.action>
     <fmt.skip>false</fmt.skip>
-    <fork.javac>false</fork.javac>
+    <fork.javac>true</fork.javac>
     <javac.maxHeapSize>256M</javac.maxHeapSize>
 
     <docker.image.prefix>${project.groupId}</docker.image.prefix>

--- a/services/wfs/src/main/java/org/geoserver/cloud/wfs/config/WfsAutoConfiguration.java
+++ b/services/wfs/src/main/java/org/geoserver/cloud/wfs/config/WfsAutoConfiguration.java
@@ -14,6 +14,6 @@ import org.springframework.context.annotation.ImportResource;
 @AutoConfigureAfter({GeoServerWebMvcMainAutoConfiguration.class})
 @ImportResource( //
     reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = "jar:gs-wfs-.*!/applicationContext.xml" //
+    locations = "jar:gs-wfs-.*!/applicationContext.xml#name=.*" //
 )
 public class WfsAutoConfiguration {}

--- a/services/wms/src/main/java/org/geoserver/cloud/wms/WmsApplicationConfiguration.java
+++ b/services/wms/src/main/java/org/geoserver/cloud/wms/WmsApplicationConfiguration.java
@@ -7,7 +7,6 @@ package org.geoserver.cloud.wms;
 import org.geoserver.cloud.config.factory.FilteringXmlBeanDefinitionReader;
 import org.geoserver.config.GeoServer;
 import org.geoserver.wfs.xml.FeatureTypeSchemaBuilder;
-import org.geoserver.wfs.xml.GML3OutputFormat;
 import org.geoserver.wfs.xml.v1_1_0.WFS;
 import org.geoserver.wfs.xml.v1_1_0.WFSConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -17,17 +16,18 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration
 @ImportResource( //
     reader = FilteringXmlBeanDefinitionReader.class, //
-    locations = "jar:gs-wms-.*!/applicationContext.xml" //
+    locations = { //
+        "jar:gs-wms-.*!/applicationContext.xml", //
+        "jar:gs-wfs-.*!/applicationContext.xml#name=" + WmsApplicationConfiguration.WFS_BEANS_REGEX
+    }
 )
 public class WmsApplicationConfiguration {
+
+    static final String WFS_BEANS_REGEX =
+            "^(gml.*OutputFormat|bboxKvpParser|xmlConfiguration.*|gml[1-9]*SchemaBuilder|wfsXsd.*|wfsSqlViewKvpParser).*$";
 
     public @Bean WFSConfiguration wfsConfiguration(GeoServer geoServer) {
         FeatureTypeSchemaBuilder schemaBuilder = new FeatureTypeSchemaBuilder.GML3(geoServer);
         return new WFSConfiguration(geoServer, schemaBuilder, new WFS(schemaBuilder));
-    }
-
-    public @Bean GML3OutputFormat gml3OutputFormat(
-            GeoServer geoServer, WFSConfiguration configuration) {
-        return new GML3OutputFormat(geoServer, configuration);
     }
 }

--- a/starters/starter-webmvc/src/main/java/org/geoserver/cloud/config/main/GeoServerMainModuleConfiguration.java
+++ b/starters/starter-webmvc/src/main/java/org/geoserver/cloud/config/main/GeoServerMainModuleConfiguration.java
@@ -41,6 +41,11 @@ import org.springframework.context.annotation.ImportResource;
     reader = FilteringXmlBeanDefinitionReader.class, //
     // exclude beans
     locations =
-            "jar:gs-main-.*!/applicationContext.xml#name=^(rawCatalog|secureCatalog|localWorkspaceCatalog|catalog|advertisedCatalog|accessRulesDao|catalogFacade|dataDirectory|extensions|geoServer|geoserverFacade|geoServerLoader|geoServerSecurityManager|resourceLoader|resourceStoreImpl|secureCatalog|xstreamPersisterFactory)$" //
+            "jar:gs-main-.*!/applicationContext.xml#name="
+                    + GeoServerMainModuleConfiguration.EXCLUDE_BEANS_REGEX
 )
-public class GeoServerMainModuleConfiguration {}
+public class GeoServerMainModuleConfiguration {
+
+    static final String EXCLUDE_BEANS_REGEX =
+            "^(?!rawCatalog|secureCatalog|localWorkspaceCatalog|catalog|advertisedCatalog|accessRulesDao|catalogFacade|dataDirectory|extensions|geoServer|geoserverFacade|geoServerLoader|geoServerSecurityManager|resourceLoader|resourceStoreImpl|secureCatalog|xstreamPersisterFactory).*$";
+}


### PR DESCRIPTION
Receives a single regular expression that represents which beans to
include, not to exclude. Added clear examples for including and
excluding based on bean names, and fixed the regular expressions used to
load the gs-main applicationContext.xml excluding the beans that are
in charge of implementations of `GeoServerBackendConfigurer`, and the
wms-service's includes of gs-wfs beans.

Fix #13, wms-service couldn't respond to GetMap queries before due to
missing wfs related beans.