### PR TITLE
Fix web-ui's redirect to internal service address

### DIFF
--- a/config/web-ui.yml
+++ b/config/web-ui.yml
@@ -32,7 +32,7 @@ geoserver:
     wfs.enabled: true
     wms.enabled: true
     wcs.enabled: true
-    wps.enabled: true
+    wps.enabled: false # not working yet
     gwc.enabled: false # not ready yet
     extensions:
       importer.enabled: true

--- a/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebUIApplicationAutoConfiguration.java
+++ b/services/web-ui/src/main/java/org/geoserver/cloud/autoconfigure/web/core/WebUIApplicationAutoConfiguration.java
@@ -4,6 +4,8 @@
  */
 package org.geoserver.cloud.autoconfigure.web.core;
 
+import javax.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
 import org.geoserver.cloud.autoconfigure.core.GeoServerWebMvcMainAutoConfiguration;
 import org.geoserver.cloud.autoconfigure.web.demo.DemosAutoConfiguration;
 import org.geoserver.cloud.autoconfigure.web.extension.ExtensionsAutoConfiguration;
@@ -13,6 +15,10 @@ import org.geoserver.cloud.autoconfigure.web.wcs.WcsAutoConfiguration;
 import org.geoserver.cloud.autoconfigure.web.wfs.WfsAutoConfiguration;
 import org.geoserver.cloud.autoconfigure.web.wms.WmsAutoConfiguration;
 import org.geoserver.cloud.autoconfigure.web.wps.WpsAutoConfiguration;
+import org.geoserver.config.GeoServer;
+import org.geoserver.config.GeoServerInfo;
+import org.geoserver.config.GeoServerInfo.WebUIMode;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -30,4 +36,18 @@ import org.springframework.context.annotation.Import;
     DemosAutoConfiguration.class,
     ToolsAutoConfiguration.class
 })
-public class WebUIApplicationAutoConfiguration {}
+@Slf4j
+public class WebUIApplicationAutoConfiguration {
+
+    private @Autowired GeoServer geoServer;
+
+    public @PostConstruct void setDefaults() {
+        GeoServerInfo global = geoServer.getGlobal();
+        WebUIMode webUIMode = global.getWebUIMode();
+        if (!WebUIMode.DO_NOT_REDIRECT.equals(webUIMode)) {
+            log.info("Forcing web-ui mode to DO_NOT_REDIRECT, was {}", webUIMode);
+            global.setWebUIMode(WebUIMode.DO_NOT_REDIRECT);
+            geoServer.save(global);
+        }
+    }
+}

--- a/starters/starter-webmvc/src/main/java/org/geoserver/cloud/config/servlet/GeoServerServletContextConfiguration.java
+++ b/starters/starter-webmvc/src/main/java/org/geoserver/cloud/config/servlet/GeoServerServletContextConfiguration.java
@@ -17,10 +17,12 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.context.request.RequestContextListener;
+import org.springframework.web.filter.ForwardedHeaderFilter;
 
 @Configuration
 public class GeoServerServletContextConfiguration {
 
+    private static final int FORWARDED_HEADER_FILTER_ORDER = 0;
     private static final int FLUSH_SAFE_FILTER_ORDER = 1;
     private static final int SESSION_DEBUG_FILTER_ORDER = 2;
     private static final int SPRING_DELEGATING_FILTER_ORDER = 3;
@@ -41,6 +43,18 @@ public class GeoServerServletContextConfiguration {
         return new RequestContextListener();
     }
     // Filters
+
+    /**
+     * Extract values from "Forwarded" and "X-Forwarded-*" headers, wrap the request and response,
+     * and make they reflect the client-originated protocol and address.
+     */
+    public @Bean ForwardedHeaderFilter forwardedHeaderFilter() {
+        return new ForwardedHeaderFilter();
+    }
+
+    public @Bean FilterRegistrationBean<ForwardedHeaderFilter> forwardedHeaderFilterReg() {
+        return newRegistration(forwardedHeaderFilter(), FORWARDED_HEADER_FILTER_ORDER);
+    }
 
     /**
      * A servlet filter making sure we cannot end up calling flush() on the response output stream


### PR DESCRIPTION
Fix #14 

- `org.springframework.web.filter.ForwardedHeaderFilter` replaces the request's address components by the ones provided by the gateway service in the X-Forwarded* headers, fixing the redirect to internal address issue.
- force `WebUIMode.DO_NOT_REDIRECT` at startup