### PR TITLE
Enable build against gs latest stable version with a maven profile

### DIFF
--- a/.github/workflows/ci-gs-stable.yaml
+++ b/.github/workflows/ci-gs-stable.yaml
@@ -12,9 +12,6 @@ jobs:
     name: Build and Test 
     runs-on: [ubuntu-latest]
     timeout-minutes: 60
-    env:
-      GS_VERSION: 2.17.2
-      GT_VERSION: 23.2
     steps:
     - name: Checkout project
       uses: actions/checkout@v1
@@ -33,13 +30,13 @@ jobs:
           gscloud-gs-stable-${{ runner.os }}-maven-
 
     - name: Update maven dependencies
-      run: ./mvnw -Dgs.version=${GS_VERSION} -Dgt.version=${GT_VERSION} -P\!docker de.qaware.maven:go-offline-maven-plugin:resolve-dependencies --no-transfer-progress
+      run: ./mvnw -P\!docker,geoserver_stable_version de.qaware.maven:go-offline-maven-plugin:resolve-dependencies --no-transfer-progress
 
     - name: Build without tests
-      run: ./mvnw -Dgs.version=${GS_VERSION} -Dgt.version=${GT_VERSION} -P\!docker -ntp -Dfmt.action=check install -T1C -DskipTests
+      run: ./mvnw -P\!docker,geoserver_stable_version -ntp -Dfmt.action=check install -T1C -DskipTests
 
     - name: Test
-      run: ./mvnw -Dgs.version=${GS_VERSION} -Dgt.version=${GT_VERSION} -P\!docker -ntp verify -T1C -fae
+      run: ./mvnw -P\!docker,geoserver_stable_version -ntp verify -T1C -fae
 
     - name: Remove project jars from cached repository
       run: |

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ To build the application run maven from the root project directory run
 
     ./mvnw clean install
 
-The main branch follows GeoServer's main branch, currently `2.18-SNAPSHOT`. It's also possible to build against the latest stable version, as follows:
+The main branch follows GeoServer's main branch, currently `2.18-SNAPSHOT`. It's also possible to build against the latest stable version, activate the `geoserver_stable_version` profile as follows:
 
-    ./mvnw clean install -Dgs.version=2.17.2
+    ./mvnw clean install -P geoserver_stable_version
 
 ## Running
 

--- a/pom.xml
+++ b/pom.xml
@@ -723,4 +723,13 @@
     <module>starters</module>
     <module>services</module>
   </modules>
+  <profiles>
+    <profile>
+      <id>geoserver_stable_version</id>
+      <properties>
+        <gs.version>2.17.2</gs.version>
+        <gt.version>23.2</gt.version>
+      </properties>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Instead of having to explicitly override the geoserver and geotools
versions as maven arguments, use a profile:
`mvn -P geoserver_stable_version`.